### PR TITLE
Added ZIM Counter metadata parsing support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,4 @@ repos:
     rev: "3.9.2"
     hooks:
     -   id: flake8
-        args: ["--max-line-length", "88"]
+        args: ["--max-line-length", "88", "--extend-ignore=E203"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 1.4.1
 
-* n/a
+* New `Counter` metadata based properties for Archive:
+  * `.counters`: parsed dict of the Counter metadata
+  * `.article_counter`: libkiwix's calculation for nb or article
+  * `.media_counter`: libkiwix's calculation for nb or media
 
 # 1.4.0
 

--- a/src/zimscraperlib/zim/_libkiwix.py
+++ b/src/zimscraperlib/zim/_libkiwix.py
@@ -28,10 +28,12 @@ def getline(src: io.StringIO, delim: Optional[bool] = None) -> Tuple[bool, str]:
     if not delim:
         return True, src.read()
 
-    while char := src.read(1):
+    char = src.read(1)
+    while char:
         if char == delim:
             break
         output += char
+        char = src.read(1)
     return char == "", output
 
 

--- a/src/zimscraperlib/zim/_libkiwix.py
+++ b/src/zimscraperlib/zim/_libkiwix.py
@@ -1,0 +1,104 @@
+r""" [INTERNAL] libkiwix's internal features copies
+
+CAUTION: this is __not__ part of zimscraperlib's API. Don't use outside scraperlib!
+
+Following methods are direct copies of libkiwix's for which there is a need to
+in scraperlib. The goal is not to reimplement similar features but to stick as much
+as possible to the original source code so that upstream changes can be backported
+easily. Hence the unexpected method names and formatting.
+
+https://github.com/kiwix/libkiwix/blob/master/src/reader.cpp
+https://github.com/kiwix/libkiwix/blob/master/src/tools/archiveTools.cpp
+"""
+
+import io
+from collections import namedtuple
+from typing import Dict, Optional, Tuple
+
+MimetypeAndCounter = namedtuple("MimetypeAndCounter", ["mimetype", "value"])
+CounterMap = Dict[type(MimetypeAndCounter.mimetype), type(MimetypeAndCounter.value)]
+
+
+def getline(src: io.StringIO, delim: Optional[bool] = None) -> Tuple[bool, str]:
+    """C++ stdlib getline() ~clone
+
+    Reads `src` until it finds `delim`.
+    returns whether src is EOF and the extracted string (delim excluded)"""
+    output = ""
+    if not delim:
+        return True, src.read()
+
+    while char := src.read(1):
+        if char == delim:
+            break
+        output += char
+    return char == "", output
+
+
+def readFullMimetypeAndCounterString(src: io.StringIO) -> Tuple[bool, str]:
+    """read a single mimetype-and-counter string from source
+
+    Returns whether the source is EOF and the extracted string (or empty one)"""
+    params = ""
+    eof, mtcStr = getline(src, ";")
+    if mtcStr.find("=") == -1:
+        while params.count("=") != 2:
+            eof, params = getline(src, ";")
+            if params.count("=") == 2:
+                mtcStr += ";" + params
+            if eof:
+                break
+    return eof, mtcStr
+
+
+def parseASingleMimetypeCounter(string: str) -> MimetypeAndCounter:
+    """MimetypeAndCounter from a single mimetype-and-counter string"""
+    k: int = string.rfind("=")
+    if k != len(string) - 1:
+        mimeType = string[:k]
+        counter = string[k + 1 :]
+        if counter:
+            try:
+                return MimetypeAndCounter(mimeType, int(counter))
+            except ValueError:
+                pass  # value is not castable to int
+    return MimetypeAndCounter("", 0)
+
+
+def parseMimetypeCounter(
+    counterData: str,
+) -> CounterMap:
+    """Mapping of MIME types with count for each from ZIM Counter metadata string"""
+    counters = dict()
+    ss = io.StringIO(counterData)
+    eof = False
+    while not eof:
+        eof, mtcStr = readFullMimetypeAndCounterString(ss)
+        mtc = parseASingleMimetypeCounter(mtcStr)
+        if mtc.mimetype:
+            counters.update([mtc])
+    return counters
+
+
+def getArticleCount(counterMap: CounterMap):
+    """Get the count of articles which can be indexed/displayed"""
+    counter = 0
+    for mimetype, count in counterMap.items():
+        if mimetype.startswith("text/html"):
+            counter += count
+
+    return counter
+
+
+def getMediaCount(counterMap: CounterMap) -> int:
+    """Get the count of medias content in the ZIM file"""
+    counter = 0
+    for mimetype, count in counterMap.items():
+        if (
+            mimetype.startswith("image/")
+            or mimetype.startswith("video/")
+            or mimetype.startswith("audio/")
+        ):
+            counter += count
+
+    return counter

--- a/src/zimscraperlib/zim/archive.py
+++ b/src/zimscraperlib/zim/archive.py
@@ -16,6 +16,7 @@ import libzim.reader
 import libzim.search  # Query, Searcher
 import libzim.suggestion  # SuggestionSearcher
 
+from ._libkiwix import getArticleCount, getMediaCount, parseMimetypeCounter
 from .items import Item
 
 
@@ -78,3 +79,27 @@ class Archive(libzim.reader.Archive):
             libzim.search.Query().set_query(query)
         )
         return search.getEstimatedMatches()
+
+    @property
+    def counters(self) -> Dict[str, int]:
+        """Parsed `Counter` metadata
+
+        Cached into _counters"""
+
+        def parse_counters():
+            self._counters = parseMimetypeCounter(
+                self.get_metadata("Counter").decode("UTF-8")
+            )
+            return self._counters
+
+        return getattr(self, "_counters", parse_counters())
+
+    @property
+    def article_counter(self) -> int:
+        """Nb of *articles* in the ZIM, using counters (from libkiwix)"""
+        return getArticleCount(self.counters)
+
+    @property
+    def media_counter(self) -> int:
+        """Nb of *medias* in the ZIM, using counters (from libkiwix)"""
+        return getMediaCount(self.counters)

--- a/tests/zim/conftest.py
+++ b/tests/zim/conftest.py
@@ -58,3 +58,28 @@ def build_data(tmp_path, png_image):
         "redirects": [("picture", "commons.png", "")],
         "redirects_file": redirects_file,
     }
+
+
+@pytest.fixture(scope="function")
+def counters():
+    return {
+        "application/javascript": 8,
+        "text/html": 3,
+        "application/warc-headers": 28364,
+        "text/html;raw=true": 6336,
+        "text/css": 47,
+        "text/javascript": 98,
+        "image/png": 968,
+        "image/webp": 24,
+        "application/json": 3694,
+        "image/gif": 10274,
+        "image/jpeg": 1582,
+        "font/woff2": 25,
+        "text/plain": 284,
+        "application/atom+xml": 247,
+        "application/x-www-form-urlencoded": 9,
+        "video/mp4": 9,
+        "application/x-javascript": 7,
+        "application/xml": 1,
+        "image/svg+xml": 5,
+    }

--- a/tests/zim/test_archive.py
+++ b/tests/zim/test_archive.py
@@ -59,3 +59,18 @@ def test_search(real_zim_file):
     with Archive(real_zim_file) as zim:
         assert zim.get_search_results_count("test") > 0
         assert "A/Diesel_emissions_scandal" in list(zim.get_search_results("test"))
+
+
+def test_counters(small_zim_file):
+    with Archive(small_zim_file) as zim:
+        assert zim.counters == {"image/png": 1, "text/html": 1}
+
+
+def test_article_counter(small_zim_file):
+    with Archive(small_zim_file) as zim:
+        assert zim.article_counter == 1
+
+
+def test_media_counter(small_zim_file):
+    with Archive(small_zim_file) as zim:
+        assert zim.media_counter == 1


### PR DESCRIPTION
Archive now supports `.counters`, `.article_counter` and `.media_counter`, providing
respectively a parsed dict of the Counter metadata and libkiwix's calculations
for articles and medias.

Implemented as copies of libkiwix code in a private module.
Tests are duplicates of libkiwix's to ensure compatibility

Also adding an ignore rule for flake8. See https://github.com/psf/black/issues/315