### PR TITLE
Support for enabling full-text index and compression on demand

### DIFF
--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -73,7 +73,7 @@ class Creator(libzim.writer.Creator):
         self,
         filename: pathlib.Path,
         main_path: str = None,
-        language: Optional[str] = "eng",
+        language: Optional[str] = None,
         compression: Optional[str] = None,
         workaround_nocancel: Optional[bool] = True,
         **metadata: Dict[str, Union[str, datetime.date, datetime.datetime]]
@@ -91,6 +91,8 @@ class Creator(libzim.writer.Creator):
                 metadata.update(ld)
             else:
                 metadata = ld
+        else:
+            self.config_indexing(False, language)
 
         if compression:
             self.config_compression(
@@ -98,6 +100,8 @@ class Creator(libzim.writer.Creator):
                 if isinstance(compression, str)
                 else compression
             )
+        else:
+            self.config_compression('None')
 
         if metadata:
             self.metadata = metadata

--- a/src/zimscraperlib/zim/filesystem.py
+++ b/src/zimscraperlib/zim/filesystem.py
@@ -125,7 +125,7 @@ def make_zim_file(
     source: str = None,
     flavour: str = None,
     scraper: str = None,
-    without_fulltext_index: bool = False,
+    without_fulltext_index: bool = True,
     redirects: Sequence[Tuple[str, str, str]] = None,
     redirects_file: pathlib.Path = None,
     rewrite_links: bool = True,
@@ -152,7 +152,7 @@ def make_zim_file(
     zim_file = Creator(
         filename=fpath,
         main_path=main_page,
-        index_language="" if without_fulltext_index else language,
+        index_language=None if without_fulltext_index else language,
         **{
             k: v
             for k, v in {


### PR DESCRIPTION
This PR responds to issue openzim/sotoki/issues/243.

Disables the full text indexing and compression by default so that it's memory cost is only payed if requested (which can be an issue with big sites).
