### PR TITLE
Introduce the `MetadataDict`

### DIFF
--- a/src/zimscraperlib/constants.py
+++ b/src/zimscraperlib/constants.py
@@ -20,15 +20,15 @@ FRONT_ARTICLE_MIMETYPES = ["text/html"]
 
 # list of mandatory meta tags of the zim file.
 ZIM_MANDATORY_METADATA_KEYS = [
-    "Name",
-    "Title",
-    "Creator",
-    "Publisher",
-    "Date",
-    "Description",
-    "Language",
-    "Illustration_48x48@1",
+    "name",
+    "title",
+    "creator",
+    "publisher",
+    "date",
+    "description",
+    "language",
 ]
 
+# Default Value of Language
 DEFAULT_LANG_ISO_639_1 = "en"
 DEFAULT_LANG_ISO_639_3 = "eng"

--- a/src/zimscraperlib/constants.py
+++ b/src/zimscraperlib/constants.py
@@ -17,3 +17,18 @@ ALPHA_NOT_SUPPORTED = ["JPEG", "BMP", "EPS", "PCX"]
 
 # list of mimetypes we consider articles using it should default to FRONT_ARTICLE
 FRONT_ARTICLE_MIMETYPES = ["text/html"]
+
+# list of mandatory meta tags of the zim file.
+ZIM_MANDATORY_METADATA_KEYS = [
+    "Name",
+    "Title",
+    "Creator",
+    "Publisher",
+    "Date",
+    "Description",
+    "Language",
+    "Illustration_48x48@1",
+]
+
+DEFAULT_LANG_ISO_639_1 = "en"
+DEFAULT_LANG_ISO_639_3 = "eng"

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -30,6 +30,7 @@ from ..constants import FRONT_ARTICLE_MIMETYPES
 from ..filesystem import delete_callback, get_content_mimetype, get_file_mimetype
 from ..types import get_mime_for_name
 from .items import StaticItem
+from .metadata_dict import MetadataDict
 
 DUPLICATE_EXC_STR = re.compile(
     r"^Impossible to add(.+)"
@@ -89,6 +90,7 @@ class Creator(libzim.writer.Creator):
     ):
         super().__init__(filename=filename)
         self.can_finish = True
+        self.metadata = MetadataDict()
 
         if main_path:
             self.main_path = main_path
@@ -111,7 +113,7 @@ class Creator(libzim.writer.Creator):
             )
 
         if metadata:
-            self.metadata = metadata
+            self.metadata.update(metadata)
 
         self.workaround_nocancel = workaround_nocancel
         self.ignore_duplicates = ignore_duplicates
@@ -124,6 +126,10 @@ class Creator(libzim.writer.Creator):
 
         if getattr(self, "metadata", None):
             self.update_metadata(**self.metadata)
+
+        if not self.metadata.all_are_set:
+            raise ValueError(f"{self.metadata} Mandatory Metadata are not all set.")
+
         return self
 
     def update_metadata(self, **kwargs):

--- a/src/zimscraperlib/zim/metadata_dict.py
+++ b/src/zimscraperlib/zim/metadata_dict.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4 nu
+
+import collections
+import datetime
+
+from ..constants import DEFAULT_LANG_ISO_639_3, ZIM_MANDATORY_METADATA_KEYS
+from ..i18n import get_iso_lang_data
+
+"""MetadataDict
+   Convenient subclass of UserDict:
+   - Automatic initialization of all mandatory Metadata.
+   - Determine if all mandatory Metadata are set."""
+
+
+class MetadataDict(collections.UserDict):
+    def __init__(self):
+        super().__init__()
+        default_data = {key: "" for key in ZIM_MANDATORY_METADATA_KEYS}
+        fix_default_data = {
+            "Language": DEFAULT_LANG_ISO_639_3,
+            "Date": datetime.datetime.today(),
+        }
+        default_data.update(fix_default_data)
+        self.update(default_data)
+
+    def __setitem__(self, key, item):
+        super().__setitem__(key.capitalize(), item)
+
+    def update(self, dict):
+        dict = {key.capitalize(): value for key, value in dict.items()}
+        super().update(dict)
+
+    def __check_languages_type(self):
+        languages_iso_639_3 = self.get("Language", default="").split(",")
+        for language in languages_iso_639_3:
+            get_iso_lang_data(language)
+
+    def __check_date_type(self):
+        content = self.get("Date", default="")
+        if not isinstance(content, (datetime.date, datetime.datetime)):
+            date.fromisoformat(content)
+
+    def check_values_type(self):
+        self.__check_languages_type()
+        self.__check_date_type()
+
+    @property
+    def mandatory_values_all_set(self):
+        if any([not self.data[key] for key in ZIM_MANDATORY_METADATA_KEYS]):
+            return False
+        return True
+
+    @property
+    def unset_keys(self):
+        return [key for key, value in self.data.items() if not value]

--- a/src/zimscraperlib/zim/metadata_dict.py
+++ b/src/zimscraperlib/zim/metadata_dict.py
@@ -16,7 +16,7 @@ class MetadataDict(collections.UserDict):
     """
 
     @property
-    def all_are_correct(self) -> bool:
+    def all_are_set(self) -> bool:
         """
         Determine if the Key of all mandatory Metadata has a value.
         If they all have values, return True, otherwise return False.

--- a/src/zimscraperlib/zim/metadata_dict.py
+++ b/src/zimscraperlib/zim/metadata_dict.py
@@ -3,55 +3,23 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 import collections
-import datetime
+from typing import Union
 
-from ..constants import DEFAULT_LANG_ISO_639_3, ZIM_MANDATORY_METADATA_KEYS
-from ..i18n import get_iso_lang_data
-
-"""MetadataDict
-   Convenient subclass of UserDict:
-   - Automatic initialization of all mandatory Metadata.
-   - Determine if all mandatory Metadata are set."""
+from ..constants import ZIM_MANDATORY_METADATA_KEYS
 
 
 class MetadataDict(collections.UserDict):
-    def __init__(self):
-        super().__init__()
-        default_data = {key: "" for key in ZIM_MANDATORY_METADATA_KEYS}
-        fix_default_data = {
-            "Language": DEFAULT_LANG_ISO_639_3,
-            "Date": datetime.datetime.today(),
-        }
-        default_data.update(fix_default_data)
-        self.update(default_data)
-
-    def __setitem__(self, key, item):
-        super().__setitem__(key.capitalize(), item)
-
-    def update(self, dict):
-        dict = {key.capitalize(): value for key, value in dict.items()}
-        super().update(dict)
-
-    def __check_languages_type(self):
-        languages_iso_639_3 = self.get("Language", default="").split(",")
-        for language in languages_iso_639_3:
-            get_iso_lang_data(language)
-
-    def __check_date_type(self):
-        content = self.get("Date", default="")
-        if not isinstance(content, (datetime.date, datetime.datetime)):
-            date.fromisoformat(content)
-
-    def check_values_type(self):
-        self.__check_languages_type()
-        self.__check_date_type()
+    """
+    MetadataDict
+        Convenient subclass of UserDict:
+        - Determine if all mandatory Metadata are set.
+    """
 
     @property
-    def mandatory_values_all_set(self):
-        if any([not self.data[key] for key in ZIM_MANDATORY_METADATA_KEYS]):
-            return False
-        return True
-
-    @property
-    def unset_keys(self):
-        return [key for key, value in self.data.items() if not value]
+    def all_are_correct(self) -> bool:
+        """
+        Determine if the Key of all mandatory Metadata has a value.
+        If they all have values, return True, otherwise return False.
+        """
+        lowercase_data_keys = [key.lower() for key in self.data.keys()]
+        return all([key in lowercase_data_keys for key in ZIM_MANDATORY_METADATA_KEYS])

--- a/tests/zim/test_metadata_dict.py
+++ b/tests/zim/test_metadata_dict.py
@@ -2,50 +2,15 @@ import pytest
 from zimscraperlib.zim.metadata_dict import MetadataDict
 
 
-def test_init_default_value():
+def test_all_are_correct():
     metadata = MetadataDict()
-    assert metadata["Language"] != ""
-    assert metadata["Date"] != ""
-    assert metadata["Title"] == ""
-    assert metadata["Name"] == ""
-    assert metadata["Creator"] == ""
-    assert metadata["Description"] == ""
-    assert metadata["Illustration_48x48@1"] == ""
-    assert metadata["Publisher"] == ""
-
-
-def test_update_value():
-    metadata = MetadataDict()
+    assert metadata.all_are_correct == False
     metadata["Title"] = "Test Tile"
-    metadata["Name"] = "Test Name"
+    metadata["name"] = "Test Name"
     metadata["Creator"] = "Test Creator"
+    metadata["date"] = "2022-03-09"
     metadata["Description"] = "Test Description"
-    metadata["Illustration_48x48@1"] = "Test Illustration_48x48@1"
-    metadata["Publisher"] = "Wikipedia user Foobar"
-
-    assert metadata["Title"] == "Test Tile"
-    assert metadata["Name"] == "Test Name"
-    assert metadata["Creator"] == "Test Creator"
-    assert metadata["Description"] == "Test Description"
-    assert metadata["Illustration_48x48@1"] == "Test Illustration_48x48@1"
-
-
-def test_keys_are_capitalized():
-    metadata_dict = MetadataDict()
-    metadata_dict["language"] = "zho"
-    assert metadata_dict["Language"] == "zho"
-    pass
-
-
-def test_check_all_mandatory_values():
-    metadata = MetadataDict()
-    assert metadata.mandatory_values_all_set == False
-    assert len(metadata.unset_keys) > 0
-    metadata["Title"] = "Test Tile"
-    metadata["Name"] = "Test Name"
-    metadata["Creator"] = "Test Creator"
-    metadata["Description"] = "Test Description"
-    metadata["Illustration_48x48@1"] = "Test Illustration_48x48@1"
-    metadata["Publisher"] = "Wikipedia user Foobar"
-    assert metadata.mandatory_values_all_set == True
-    assert len(metadata.unset_keys) == 0
+    assert metadata.all_are_correct == False
+    metadata["language"] = "eng"
+    metadata["Publisher"] = "Test Publisher"
+    assert metadata.all_are_correct == True

--- a/tests/zim/test_metadata_dict.py
+++ b/tests/zim/test_metadata_dict.py
@@ -1,0 +1,51 @@
+import pytest
+from zimscraperlib.zim.metadata_dict import MetadataDict
+
+
+def test_init_default_value():
+    metadata = MetadataDict()
+    assert metadata["Language"] != ""
+    assert metadata["Date"] != ""
+    assert metadata["Title"] == ""
+    assert metadata["Name"] == ""
+    assert metadata["Creator"] == ""
+    assert metadata["Description"] == ""
+    assert metadata["Illustration_48x48@1"] == ""
+    assert metadata["Publisher"] == ""
+
+
+def test_update_value():
+    metadata = MetadataDict()
+    metadata["Title"] = "Test Tile"
+    metadata["Name"] = "Test Name"
+    metadata["Creator"] = "Test Creator"
+    metadata["Description"] = "Test Description"
+    metadata["Illustration_48x48@1"] = "Test Illustration_48x48@1"
+    metadata["Publisher"] = "Wikipedia user Foobar"
+
+    assert metadata["Title"] == "Test Tile"
+    assert metadata["Name"] == "Test Name"
+    assert metadata["Creator"] == "Test Creator"
+    assert metadata["Description"] == "Test Description"
+    assert metadata["Illustration_48x48@1"] == "Test Illustration_48x48@1"
+
+
+def test_keys_are_capitalized():
+    metadata_dict = MetadataDict()
+    metadata_dict["language"] = "zho"
+    assert metadata_dict["Language"] == "zho"
+    pass
+
+
+def test_check_all_mandatory_values():
+    metadata = MetadataDict()
+    assert metadata.mandatory_values_all_set == False
+    assert len(metadata.unset_keys) > 0
+    metadata["Title"] = "Test Tile"
+    metadata["Name"] = "Test Name"
+    metadata["Creator"] = "Test Creator"
+    metadata["Description"] = "Test Description"
+    metadata["Illustration_48x48@1"] = "Test Illustration_48x48@1"
+    metadata["Publisher"] = "Wikipedia user Foobar"
+    assert metadata.mandatory_values_all_set == True
+    assert len(metadata.unset_keys) == 0

--- a/tests/zim/test_metadata_dict.py
+++ b/tests/zim/test_metadata_dict.py
@@ -4,13 +4,13 @@ from zimscraperlib.zim.metadata_dict import MetadataDict
 
 def test_all_are_correct():
     metadata = MetadataDict()
-    assert metadata.all_are_correct == False
+    assert metadata.all_are_set == False
     metadata["Title"] = "Test Tile"
     metadata["name"] = "Test Name"
     metadata["Creator"] = "Test Creator"
     metadata["date"] = "2022-03-09"
     metadata["Description"] = "Test Description"
-    assert metadata.all_are_correct == False
+    assert metadata.all_are_set == False
     metadata["language"] = "eng"
     metadata["Publisher"] = "Test Publisher"
-    assert metadata.all_are_correct == True
+    assert metadata.all_are_set == True


### PR DESCRIPTION
The goal this is PR is trying to fix three issues: #95, #87, #94
This PR includes three parts of the change: 
1. Add the `MetadataDict` class to provide some convenient methods.
2. Modify the `Creator` class to use the `MetadataDict`
3. Remove `update_metadata`, and adjust the test case.