### PR TITLE
Add Python 3.11 to CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: install ffmpeg and gifsicle
         run: sudo apt update && sudo apt install ffmpeg gifsicle


### PR DESCRIPTION
We should add Python 3.11 tests to CI, since This lib can be run under Python 3.11 now.