### PR TITLE
Fix VP8 low bitrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using openZIM Python bootstrap conventions (including hatch-openzim plugin) #120
 - Suuport for Python 3.12, drop Python 3.7 #118
 - Replace "iso-369" iso639-lang by "iso639-lang" library
+- Rework the VideoWebmLow preset for faster encoding and smaller file size (preset has been bumped to version 2)
 
 ## [3.2.0] - 2023-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Suuport for Python 3.12, drop Python 3.7 #118
 - Replace "iso-369" iso639-lang by "iso639-lang" library
 - Rework the VideoWebmLow preset for faster encoding and smaller file size (preset has been bumped to version 2)
+- When reencoding a video, ffmpeg now uses only 1 CPU thread by default (new arg to `reencode` allows to override this default value)
 
 ## [3.2.0] - 2023-12-16
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,3 @@
+
+This folder contains some tooling around zimscraperlib:
+- `encode_video.py`: a small utility to encode a video with an existing video preset, just like a scraper would do

--- a/contrib/encode_video.py
+++ b/contrib/encode_video.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+from typing import List
+
+from zimscraperlib import logger
+from zimscraperlib.video import presets, reencode
+
+
+def encode_video(src_path: Path, dst_path: Path, preset: str):
+    if not src_path.exists():
+        raise ValueError(f"{src_path} does not exists")
+    try:
+        preset_cls = getattr(presets, preset)
+    except AttributeError:
+        logger.error(f"{preset} preset not found")
+        raise
+    logger.info(f"Encoding video {src_path} with {preset} version {preset_cls.VERSION}")
+    success, process = reencode(
+        src_path=src_path,
+        dst_path=dst_path,
+        ffmpeg_args=preset_cls().to_ffmpeg_args(),
+        with_process=True,
+    )  # pyright: ignore[reportGeneralTypeIssues] (returned type is variable, depending on `with_process` value)
+    if not success:
+        logger.error(f"conversion failed:\n{process.stdout}")
+
+
+def run(args: List[str] = sys.argv):
+    if len(args) < 4:  # noqa: PLR2004
+        print(f"Usage: {args[0]} <src_path> <dst_path> <preset>")  # noqa: T201
+        print(  # noqa: T201
+            "\t<src_path>\tpath to the video to encode."
+            "\t<dst_path>\tpath to the store the reencoded video."
+            "\t<preset>\tname of preset to use."
+        )
+        return 1
+    encode_video(Path(args[1]), Path(args[2]), args[3])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ target-version = ['py38']
 [tool.ruff]
 target-version = "py38"
 line-length = 88
-src = ["src"]
+src = ["src", "contrib"]
 
 [tool.ruff.lint]
 select = [
@@ -235,7 +235,7 @@ exclude_lines = [
 ]
 
 [tool.pyright]
-include = ["src", "tests", "tasks.py"]
+include = ["contrib", "src", "tests", "tasks.py"]
 exclude = [".env/**", ".venv/**"]
 extraPaths = ["src"]
 pythonVersion = "3.8"

--- a/src/zimscraperlib/video/presets.py
+++ b/src/zimscraperlib/video/presets.py
@@ -32,7 +32,7 @@ class VideoWebmLow(Config):
     """Low Quality webm video
 
     480:h format with height adjusted to keep aspect ratio
-    200k target, 300k max video bitrate
+    128k target video bitrate but stay within quality boundaries.
     48k audio bitrate"""
 
     VERSION = 1
@@ -43,10 +43,9 @@ class VideoWebmLow(Config):
     options: ClassVar[Dict[str, Optional[Union[str, bool, int]]]] = {
         "-codec:v": "libvpx",  # video codec
         "-quality": "best",  # codec preset
-        "-b:v": "200k",  # target video bitrate
-        "-maxrate": "300k",  # max video bitrate
-        "-bufsize": "512k",  # target bitrate window
-        "-qmax": "30",  # Max quantizer scale.  Cap loss to reduce VP8 shimmer bug.
+        "-b:v": "128k", # Adjust quantizer within min/max to target this bitrate
+        "-qmin": "18",  # Reduce the bitrate on very still videos once the quality is good enough.
+        "-qmax": "40",  # Increase the bitrate on very busy videos once the quality degrades too much.  Also reduce key shimmer bug.
         "-vf": "scale='480:trunc(ow/a/2)*2'",  # frame size
         "-codec:a": "libvorbis",  # audio codec
         "-ar": "44100",  # audio sampling rate

--- a/src/zimscraperlib/video/presets.py
+++ b/src/zimscraperlib/video/presets.py
@@ -43,9 +43,9 @@ class VideoWebmLow(Config):
     options: ClassVar[Dict[str, Optional[Union[str, bool, int]]]] = {
         "-codec:v": "libvpx",  # video codec
         "-quality": "best",  # codec preset
-        "-b:v": "128k", # Adjust quantizer within min/max to target this bitrate
-        "-qmin": "18",  # Reduce the bitrate on very still videos once the quality is good enough.
-        "-qmax": "40",  # Increase the bitrate on very busy videos once the quality degrades too much.  Also reduce key shimmer bug.
+        "-b:v": "128k",  # Adjust quantizer within min/max to target this bitrate
+        "-qmin": "18",   # Reduce the bitrate on very still videos
+        "-qmax": "40",   # Increase the bitrate on very busy videos
         "-vf": "scale='480:trunc(ow/a/2)*2'",  # frame size
         "-codec:a": "libvorbis",  # audio codec
         "-ar": "44100",  # audio sampling rate

--- a/src/zimscraperlib/video/presets.py
+++ b/src/zimscraperlib/video/presets.py
@@ -44,8 +44,8 @@ class VideoWebmLow(Config):
         "-codec:v": "libvpx",  # video codec
         "-quality": "best",  # codec preset
         "-b:v": "128k",  # Adjust quantizer within min/max to target this bitrate
-        "-qmin": "18",   # Reduce the bitrate on very still videos
-        "-qmax": "40",   # Increase the bitrate on very busy videos
+        "-qmin": "18",  # Reduce the bitrate on very still videos
+        "-qmax": "40",  # Increase the bitrate on very busy videos
         "-vf": "scale='480:trunc(ow/a/2)*2'",  # frame size
         "-codec:a": "libvorbis",  # audio codec
         "-ar": "44100",  # audio sampling rate

--- a/src/zimscraperlib/video/presets.py
+++ b/src/zimscraperlib/video/presets.py
@@ -32,9 +32,8 @@ class VideoWebmLow(Config):
     """Low Quality webm video
 
     480:h format with height adjusted to keep aspect ratio
-    300k video bitrate
-    48k audio bitrate
-    highly degraded quality (30, 42)"""
+    200k target, 300k max video bitrate
+    48k audio bitrate"""
 
     VERSION = 1
 
@@ -44,11 +43,10 @@ class VideoWebmLow(Config):
     options: ClassVar[Dict[str, Optional[Union[str, bool, int]]]] = {
         "-codec:v": "libvpx",  # video codec
         "-quality": "best",  # codec preset
-        "-b:v": "300k",  # target video bitrate
+        "-b:v": "200k",  # target video bitrate
         "-maxrate": "300k",  # max video bitrate
-        "-minrate": "300k",  # min video bitrate
-        "-qmin": "30",  # min quantizer scale
-        "-qmax": "42",  # max quantizer scale
+        "-bufsize": "512k",  # target bitrate window
+        "-qmax": "30",  # Max quantizer scale.  Cap loss to reduce VP8 shimmer bug.
         "-vf": "scale='480:trunc(ow/a/2)*2'",  # frame size
         "-codec:a": "libvorbis",  # audio codec
         "-ar": "44100",  # audio sampling rate

--- a/src/zimscraperlib/video/presets.py
+++ b/src/zimscraperlib/video/presets.py
@@ -35,7 +35,7 @@ class VideoWebmLow(Config):
     128k target video bitrate but stay within quality boundaries.
     48k audio bitrate"""
 
-    VERSION = 1
+    VERSION = 2
 
     ext = "webm"
     mimetype = f"{preset_type}/webm"

--- a/tests/video/test_encoding.py
+++ b/tests/video/test_encoding.py
@@ -1,0 +1,94 @@
+import re
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+from zimscraperlib.video.encoding import _build_ffmpeg_args
+
+
+@pytest.mark.parametrize(
+    "src_path,tmp_path,ffmpeg_args,threads,expected",
+    [
+        (
+            Path("path1/file1.mp4"),
+            Path("path1/fileout.mp4"),
+            [
+                "-codec:v",
+                "libx265",
+            ],
+            None,
+            [
+                "/usr/bin/env",
+                "ffmpeg",
+                "-y",
+                "-i",
+                "file:path1/file1.mp4",
+                "-codec:v",
+                "libx265",
+                "file:path1/fileout.mp4",
+            ],
+        ),
+        (
+            Path("path2/file2.mp4"),
+            Path("path12/tmpfile.mp4"),
+            [
+                "-b:v",
+                "300k",
+            ],
+            1,
+            [
+                "/usr/bin/env",
+                "ffmpeg",
+                "-y",
+                "-i",
+                "file:path2/file2.mp4",
+                "-b:v",
+                "300k",
+                "-threads",
+                "1",
+                "file:path12/tmpfile.mp4",
+            ],
+        ),
+        (
+            Path("path2/file2.mp4"),
+            Path("path12/tmpfile.mp4"),
+            [
+                "-b:v",
+                "300k",
+                "-threads",
+                "1",
+            ],
+            1,
+            None,
+        ),
+    ],
+)
+def test_build_ffmpeg_args(
+    src_path: Path,
+    tmp_path: Path,
+    ffmpeg_args: List[str],
+    threads: Optional[int],
+    expected: Optional[List[str]],
+):
+    if expected:
+        assert (
+            _build_ffmpeg_args(
+                src_path=src_path,
+                tmp_path=tmp_path,
+                ffmpeg_args=ffmpeg_args,
+                threads=threads,
+            )
+            == expected
+        )
+    else:
+        with pytest.raises(
+            AttributeError,
+            match=re.escape("Cannot set the number of threads, already set"),
+        ):
+            _build_ffmpeg_args(
+                src_path=src_path,
+                tmp_path=tmp_path,
+                ffmpeg_args=ffmpeg_args,
+                threads=threads,
+            )

--- a/tests/video/test_video.py
+++ b/tests/video/test_video.py
@@ -143,7 +143,31 @@ def test_preset_video_webm_low():
     config = VideoWebmLow()
     assert config.VERSION == 1
     args = config.to_ffmpeg_args()
-    assert len(args) > 0
+    assert len(args) == 20
+    options_map = [
+        ("codec:v", "libvpx"),
+        ("codec:a", "libvorbis"),
+        ("b:v", "128k"),
+        ("ar", "44100"),
+        ("b:a", "48k"),
+        ("quality", "best"),
+        ("qmin", "18"),
+        ("qmax", "40"),
+        ("vf", "scale='480:trunc(ow/a/2)*2'"),
+    ]
+    for option, val in options_map:
+        idx = args.index(f"-{option}")
+        assert idx != -1
+        assert args[idx + 1] == val
+
+    # test updating values
+    config = VideoWebmLow(**{"-ar": "50000"})
+    config["-bufsize"] = "900k"
+    args = config.to_ffmpeg_args()
+    idx = args.index("-ar")
+    assert idx != -1 and args[idx + 1] == "50000"
+    idx = args.index("-bufsize")
+    assert idx != -1 and args[idx + 1] == "900k"
 
 
 def test_preset_video_webm_high():

--- a/tests/video/test_video.py
+++ b/tests/video/test_video.py
@@ -143,34 +143,7 @@ def test_preset_video_webm_low():
     config = VideoWebmLow()
     assert config.VERSION == 1
     args = config.to_ffmpeg_args()
-    assert len(args) == 24
-    options_map = [
-        ("codec:v", "libvpx"),
-        ("codec:a", "libvorbis"),
-        ("maxrate", "300k"),
-        ("minrate", "300k"),
-        ("b:v", "300k"),
-        ("ar", "44100"),
-        ("b:a", "48k"),
-        ("quality", "best"),
-        ("qmin", "30"),
-        ("qmax", "42"),
-        ("vf", "scale='480:trunc(ow/a/2)*2'"),
-    ]
-    for option, val in options_map:
-        idx = args.index(f"-{option}")
-        assert idx != -1
-        assert args[idx + 1] == val
-
-    # test updating values
-    config = VideoWebmLow(**{"-ar": "50000"})
-    config["-bufsize"] = "900k"
-    args = config.to_ffmpeg_args()
-    idx = args.index("-ar")
-    assert idx != -1 and args[idx + 1] == "50000"
-    idx = args.index("-bufsize")
-    assert idx != -1 and args[idx + 1] == "900k"
-
+    assert len(args) > 0
 
 def test_preset_video_webm_high():
     config = VideoWebmHigh()

--- a/tests/video/test_video.py
+++ b/tests/video/test_video.py
@@ -145,6 +145,7 @@ def test_preset_video_webm_low():
     args = config.to_ffmpeg_args()
     assert len(args) > 0
 
+
 def test_preset_video_webm_high():
     config = VideoWebmHigh()
     assert config.VERSION == 1

--- a/tests/video/test_video.py
+++ b/tests/video/test_video.py
@@ -141,7 +141,7 @@ def test_preset_has_mime_and_ext():
 
 def test_preset_video_webm_low():
     config = VideoWebmLow()
-    assert config.VERSION == 1
+    assert config.VERSION == 2
     args = config.to_ffmpeg_args()
     assert len(args) == 20
     options_map = [


### PR DESCRIPTION
# Edits by @benoit74 

Enabler for https://github.com/openzim/kolibri/issues/75
Fix #123 

## Changes
- Rework the VideoWebmLow preset for faster encoding and smaller file size (preset has been bumped to version 2)
  - target bitrate `-b:v` is reduced to 128k instead of 300k (deemed sufficient)
  - `-maxrate` and `-minrate` have been removed (otherwise the quantizer has no room for adaptation)
  - `-qmin` is reduced to 18 instead of 30 (significantly reduce the bitrate on very still videos)
  - `-qmax` is decreased to 40 instead of 42 
  - other settings are left as-is
- When reencoding a video, ffmpeg now uses only 1 CPU thread by default (new arg to `reencode` allows to override this default value)
- New utility to encode a video with an existing preset (for local debugging typically)

# Original comment

https://github.com/openzim/kolibri/issues/75

The VP8 values appear to have been copied from the x264 options but these codecs do not share the same scale.

Removed contradictory options.  Use ordinary average bitrate target with min/max bounds on quality.
