### PR TITLE
Fix handling of tag list in Creator.add_metadata (fix #125)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,3 +240,4 @@ exclude = [".env/**", ".venv/**"]
 extraPaths = ["src"]
 pythonVersion = "3.8"
 typeCheckingMode="basic"
+disableBytesTypePromotions = true

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -183,10 +183,15 @@ class Creator(libzim.writer.Creator):
     def add_metadata(
         self,
         name: str,
-        content: Union[str, bytes, datetime.date, datetime.datetime],
+        content: Union[str, bytes, datetime.date, datetime.datetime, Iterable[str]],
         mimetype: str = "text/plain;charset=UTF-8",
     ):
         self.validate_metadata(name, content)
+        # handle necessary type conversions
+        if name == "Tags" and not isinstance(content, str):
+            # join list of tags into a single string
+            content = ";".join(content)
+        # NOTE: conversion of "Date" is handled in python-libzim
         super().add_metadata(name, content, mimetype)
 
     def config_metadata(

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -187,6 +187,8 @@ class Creator(libzim.writer.Creator):
         mimetype: str = "text/plain;charset=UTF-8",
     ):
         self.validate_metadata(name, content)
+        if name == "Date" and isinstance(content, (datetime.date, datetime.datetime)):
+            content = content.strftime("%Y-%m-%d").encode("UTF-8")
         if name == "Tags" and not isinstance(content, str):
             content = ";".join(content)
         super().add_metadata(name, content, mimetype)

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -17,6 +17,7 @@
     - content stored on object
     - can be used to store a filepath and content read from it (not stored) """
 
+import collections.abc
 import datetime
 import pathlib
 import re
@@ -189,7 +190,12 @@ class Creator(libzim.writer.Creator):
         self.validate_metadata(name, content)
         if name == "Date" and isinstance(content, (datetime.date, datetime.datetime)):
             content = content.strftime("%Y-%m-%d").encode("UTF-8")
-        if name == "Tags" and not isinstance(content, str):
+        if (
+            name == "Tags"
+            and not isinstance(content, str)
+            and not isinstance(content, bytes)
+            and isinstance(content, collections.abc.Iterable)
+        ):
             content = ";".join(content)
         super().add_metadata(name, content, mimetype)
 

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -187,11 +187,8 @@ class Creator(libzim.writer.Creator):
         mimetype: str = "text/plain;charset=UTF-8",
     ):
         self.validate_metadata(name, content)
-        # handle necessary type conversions
         if name == "Tags" and not isinstance(content, str):
-            # join list of tags into a single string
             content = ";".join(content)
-        # NOTE: conversion of "Date" is handled in python-libzim
         super().add_metadata(name, content, mimetype)
 
     def config_metadata(

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -514,7 +514,26 @@ def test_check_metadata(tmp_path):
         Creator(tmp_path, "").config_dev_metadata(LongDescription="T" * 5000).start()
 
 
-def test_config_metadata(tmp_path, png_image):
+@pytest.mark.parametrize(
+    "tags",
+    [
+        (
+            "wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:yes;"
+            "_ftindex:yes"
+        ),
+        (
+            [
+                "wikipedia",
+                "_category:wikipedia",
+                "_pictures:no",
+                "_videos:no",
+                "_details:yes",
+                "_ftindex:yes",
+            ]
+        ),
+    ],
+)
+def test_config_metadata(tmp_path, png_image, tags):
     fpath = tmp_path / "test_config.zim"
     with open(png_image, "rb") as fh:
         png_data = fh.read()
@@ -529,8 +548,7 @@ def test_config_metadata(tmp_path, png_image):
         " from the english Wikipedia by 2009-11-10. The topics are...",
         Language="eng",
         License="CC-BY",
-        Tags="wikipedia;_category:wikipedia;_pictures:no;_videos:no;"
-        "_details:yes;_ftindex:yes",
+        Tags=tags,
         Flavour="nopic",
         Source="https://en.wikipedia.org/",
         Scraper="mwoffliner 1.2.3",
@@ -571,54 +589,6 @@ def test_config_metadata(tmp_path, png_image):
     assert reader.get_text_metadata("Scraper") == "mwoffliner 1.2.3"
     assert reader.get_metadata("Illustration_48x48@1") == png_data
     assert reader.get_text_metadata("TestMetadata") == "Test Metadata"
-
-
-def test_creator_metadata_list_as_tags(tmp_path, png_image):
-    """
-    Test creator metadata setup when "Tags" is a list of strings.
-
-    The test case is based on test_config_metadata()
-
-    This is also a regression test for #125.
-    """
-    fpath = tmp_path / "test_config.zim"
-    with open(png_image, "rb") as fh:
-        png_data = fh.read()
-    creator = Creator(fpath, "").config_metadata(
-        Name="wikipedia_fr_football",
-        Title="English Wikipedia",
-        Creator="English speaking Wikipedia contributors",
-        Publisher="Wikipedia user Foobar",
-        Date="2009-11-21",
-        Description="All articles (without images) from the english Wikipedia",
-        LongDescription="This ZIM file contains all articles (without images)"
-        " from the english Wikipedia by 2009-11-10. The topics are...",
-        Language="eng",
-        License="CC-BY",
-        Tags=[
-            "wikipedia",
-            "_category:wikipedia",
-            "_pictures:no",
-            "_videos:no",
-            "_details:yes",
-            "_ftindex:yes",
-        ],
-        Flavour="nopic",
-        Source="https://en.wikipedia.org/",
-        Scraper="mwoffliner 1.2.3",
-        Illustration_48x48_at_1=png_data,
-        TestMetadata="Test Metadata",
-    )
-    with creator:
-        pass
-
-    assert fpath.exists()
-    reader = Archive(fpath)
-    assert (
-        reader.get_text_metadata("Tags")
-        == "wikipedia;_category:wikipedia;_pictures:no;_videos:no;"
-        "_details:yes;_ftindex:yes"
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -573,6 +573,54 @@ def test_config_metadata(tmp_path, png_image):
     assert reader.get_text_metadata("TestMetadata") == "Test Metadata"
 
 
+def test_creator_metadata_list_as_tags(tmp_path, png_image):
+    """
+    Test creator metadata setup when "Tags" is a list of strings.
+
+    The test case is based on test_config_metadata()
+
+    This is also a regression test for #125.
+    """
+    fpath = tmp_path / "test_config.zim"
+    with open(png_image, "rb") as fh:
+        png_data = fh.read()
+    creator = Creator(fpath, "").config_metadata(
+        Name="wikipedia_fr_football",
+        Title="English Wikipedia",
+        Creator="English speaking Wikipedia contributors",
+        Publisher="Wikipedia user Foobar",
+        Date="2009-11-21",
+        Description="All articles (without images) from the english Wikipedia",
+        LongDescription="This ZIM file contains all articles (without images)"
+        " from the english Wikipedia by 2009-11-10. The topics are...",
+        Language="eng",
+        License="CC-BY",
+        Tags=[
+            "wikipedia",
+            "_category:wikipedia",
+            "_pictures:no",
+            "_videos:no",
+            "_details:yes",
+            "_ftindex:yes",
+        ],
+        Flavour="nopic",
+        Source="https://en.wikipedia.org/",
+        Scraper="mwoffliner 1.2.3",
+        Illustration_48x48_at_1=png_data,
+        TestMetadata="Test Metadata",
+    )
+    with creator:
+        pass
+
+    assert fpath.exists()
+    reader = Archive(fpath)
+    assert (
+        reader.get_text_metadata("Tags")
+        == "wikipedia;_category:wikipedia;_pictures:no;_videos:no;"
+        "_details:yes;_ftindex:yes"
+    )
+
+
 @pytest.mark.parametrize(
     "name,value,valid",
     [


### PR DESCRIPTION
Fixes #125

Previously, the type annotations of `Creator.config_metadata()` allowed "Tags" to be a list of strings, but didn't handle the conversion to a string, which resulted in python-libzim raising an error.

This commit modifies `Creator.add_metadata()` to accept a list of strings and, if the key of the metadata is "Tags", join them into a single string. A regression test is included. The metadata validation seems have already been written with a tag list in mind (though there is no check that a single tag in such a list should not contain `";"`, not sure if this is intended).

**Note:** the join has been implemented in `Creator.add_metadata`, but the conversion of `datetime.datetime` for the `"Date"` metadata key happens in `python-libzim`. I think splitting the conversion logic between those two libraries is suboptimal, we should  consider implementing the tag list conversion in `python-libzim` instead.