### PR TITLE
Fix type hints

### DIFF
--- a/src/zimscraperlib/image/convertion.py
+++ b/src/zimscraperlib/image/convertion.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+import io
 import pathlib
-from typing import Optional
+from typing import Union
 
 import PIL
 
@@ -13,7 +14,9 @@ from zimscraperlib.image.utils import save_image
 
 
 def convert_image(
-    src: pathlib.Path, dst: pathlib.Path, **params: Optional[dict]
+    src: Union[pathlib.Path, io.BytesIO],
+    dst: Union[pathlib.Path, io.BytesIO],
+    **params: str,
 ) -> None:
     """convert an image file from one format to another
     params: Image.save() parameters. Depends on dest format.

--- a/src/zimscraperlib/image/transformation.py
+++ b/src/zimscraperlib/image/transformation.py
@@ -19,7 +19,7 @@ def resize_image(
     dst: Optional[Union[pathlib.Path, io.BytesIO]] = None,
     method: Optional[str] = "width",
     allow_upscaling: Optional[bool] = True,  # noqa: FBT002
-    **params: Optional[dict],
+    **params: str,
 ) -> None:
     """resize an image to requested dimensions
 

--- a/src/zimscraperlib/image/utils.py
+++ b/src/zimscraperlib/image/utils.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+import io
 import pathlib
-from typing import Optional
+from typing import Optional, Union
 
 from PIL import Image
 
 
 def save_image(
     src: Image,  # pyright: ignore
-    dst: pathlib.Path,
+    dst: Union[pathlib.Path, io.BytesIO],
     fmt: Optional[str] = None,
-    **params: Optional[dict],
+    **params: str,
 ) -> None:
     """PIL.Image.save() wrapper setting default parameters"""
     args = {"JPEG": {"quality": 100}, "PNG": {}}.get(fmt, {})  # pyright: ignore

--- a/src/zimscraperlib/zim/filesystem.py
+++ b/src/zimscraperlib/zim/filesystem.py
@@ -46,8 +46,8 @@ class FileItem(StaticItem):
         self,
         root: pathlib.Path,
         filepath: pathlib.Path,
-    ):  # pyright: ignore
-        super().__init__(root=root, filepath=filepath)  # pyright: ignore
+    ):
+        super().__init__(root=root, filepath=filepath)
         # first look inside the file's magic headers
         self.mimetype = get_file_mimetype(self.filepath)
         # most web-specific files are plain text. In this case, use extension

--- a/src/zimscraperlib/zim/filesystem.py
+++ b/src/zimscraperlib/zim/filesystem.py
@@ -47,7 +47,9 @@ class FileItem(StaticItem):
         root: pathlib.Path,
         filepath: pathlib.Path,
     ):
-        super().__init__(root=root, filepath=filepath)
+        super().__init__()
+        self.root = root
+        self.filepath = filepath
         # first look inside the file's magic headers
         self.mimetype = get_file_mimetype(self.filepath)
         # most web-specific files are plain text. In this case, use extension

--- a/src/zimscraperlib/zim/items.py
+++ b/src/zimscraperlib/zim/items.py
@@ -9,7 +9,7 @@ import pathlib
 import re
 import tempfile
 import urllib.parse
-from typing import Dict, Union
+from typing import Any
 
 import libzim.writer  # pyright: ignore
 
@@ -23,11 +23,9 @@ from zimscraperlib.zim.providers import (
 
 
 class Item(libzim.writer.Item):
-    """libzim.writer.Item returning props for path/title/mimetype plus a callback
+    """libzim.writer.Item returning props for path/title/mimetype"""
 
-    Calls your `callback` prop on deletion"""
-
-    def __init__(self, **kwargs: Dict[str, Union[str, bool, bytes]]):
+    def __init__(self, **kwargs: Any):
         super().__init__()
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -106,7 +104,7 @@ class URLItem(StaticItem):
         size, _ = stream_file(url.geturl(), fpath=fpath, byte_stream=stream)
         return fpath or stream, size
 
-    def __init__(self, url: str, **kwargs):
+    def __init__(self, url: str, **kwargs: Any):
         super().__init__(**kwargs)
         self.url = urllib.parse.urlparse(url)
         use_disk = getattr(self, "use_disk", False)

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -296,6 +296,30 @@ def test_change_image_format_defaults(png_image, tmp_path):
     assert dst_image.format == "WEBP"
 
 
+def test_convert_io_src_dst(png_image: pathlib.Path):
+    src = io.BytesIO(png_image.read_bytes())
+    dst = io.BytesIO()
+    convert_image(src, dst, fmt="PNG")
+    dst_image = Image.open(dst)
+    assert dst_image.format == "PNG"
+
+
+def test_convert_io_src_path_dst(png_image: pathlib.Path, tmp_path: pathlib.Path):
+    src = io.BytesIO(png_image.read_bytes())
+    dst = tmp_path / "test.png"
+    convert_image(src, dst, fmt="PNG")
+    dst_image = Image.open(dst)
+    assert dst_image.format == "PNG"
+
+
+def test_convert_path_src_io_dst(png_image: pathlib.Path):
+    src = png_image
+    dst = io.BytesIO()
+    convert_image(src, dst, fmt="PNG")
+    dst_image = Image.open(dst)
+    assert dst_image.format == "PNG"
+
+
 @pytest.mark.parametrize(
     "fmt,exp_size",
     [("png", 128), ("jpg", 128)],

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -40,6 +40,8 @@ class SpecialURLProviderItem(StaticItem):
 
 class FileLikeProviderItem(StaticItem):
     def get_contentprovider(self):
+        if not self.fileobj:
+            raise AttributeError("fileobj cannot be None")
         return FileLikeProvider(self.fileobj)
 
 

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -4,7 +4,6 @@
 import base64
 import datetime
 import io
-import os
 import pathlib
 import random
 import shutil
@@ -119,7 +118,7 @@ def test_noindexlanguage(tmp_path):
     creator = Creator(fpath, "welcome").config_dev_metadata(Language="bam")
     creator.config_indexing(False)
     with creator as creator:
-        creator.add_item(StaticItem(path="welcome", content="hello"))  # pyright: ignore
+        creator.add_item(StaticItem(path="welcome", content="hello"))
         creator.add_item_for("index", "Index", content="-", mimetype="text/html")
 
     reader = Archive(fpath)
@@ -165,15 +164,11 @@ def test_add_item_for_delete_fail(tmp_path, png_image):
     # copy file to local path
     shutil.copyfile(png_image, local_path)
 
-    def remove_source(item):
-        os.remove(item.filepath)
-
     with Creator(fpath, "welcome").config_dev_metadata() as creator:
         creator.add_item(
             StaticItem(
-                filepath=local_path,  # pyright: ignore
-                path="index",  # pyright: ignore
-                callback=remove_source,  # pyright: ignore
+                filepath=local_path,
+                path="index",
             ),
             callback=(delete_callback, local_path),
         )
@@ -188,18 +183,18 @@ def test_compression(tmp_path):
     with Creator(
         tmp_path / "test.zim", "welcome", compression="zstd"
     ).config_dev_metadata() as creator:
-        creator.add_item(StaticItem(path="welcome", content="hello"))  # pyright: ignore
+        creator.add_item(StaticItem(path="welcome", content="hello"))
 
     with Creator(
         fpath, "welcome", compression=Compression.zstd  # pyright: ignore
     ).config_dev_metadata() as creator:
-        creator.add_item(StaticItem(path="welcome", content="hello"))  # pyright: ignore
+        creator.add_item(StaticItem(path="welcome", content="hello"))
 
 
 def test_double_finish(tmp_path):
     fpath = tmp_path / "test.zim"
     with Creator(fpath, "welcome").config_dev_metadata() as creator:
-        creator.add_item(StaticItem(path="welcome", content="hello"))  # pyright: ignore
+        creator.add_item(StaticItem(path="welcome", content="hello"))
 
     # ensure we can finish an already finished creator
     creator.finish()
@@ -219,11 +214,7 @@ def test_sourcefile_removal(tmp_path, html_file):
         # copy html to folder
         src_path = pathlib.Path(tmpdir.name, "source.html")
         shutil.copyfile(html_file, src_path)
-        creator.add_item(
-            StaticItem(
-                filepath=src_path, path=src_path.name, ref=tmpdir  # pyright: ignore
-            )
-        )
+        creator.add_item(StaticItem(filepath=src_path, path=src_path.name, ref=tmpdir))
         del tmpdir
 
     assert not src_path.exists()
@@ -241,7 +232,7 @@ def test_sourcefile_removal_std(tmp_path, html_file):
                 StaticItem(
                     filepath=paths[-1],
                     path=paths[-1].name,
-                    mimetype="text/html",  # pyright: ignore
+                    mimetype="text/html",
                 ),
                 callback=(delete_callback, paths[-1]),
             )


### PR DESCRIPTION
Fix #109
Fix #112 

## Rationale

Type hints were too restrictive / incorrect

## Changes

- `Item`
  - for `**kwargs`, the type specified must be the one of individual param values, not the whole dictionary 
  - the `Union[str, bool, bytes]` type hint was replaced by `Any`, because the goal of this param is precisely to pass any type which could be further used
  - `FileItem` and `URLItem` were modified as well because they were very close to `StaticItem`
  - no change was necessary in `StaticItem` in fact
  - references to callback in docstring has been removed because it has been moved to the `add_item` method quite few years ago
- `convert_image`
  - `src` and `dst` can be either a `Pathlib.Path` or an `io.BytesIO` (maybe even `typing.BinaryIO` or `typing.IO[bytes]`, but I did not find a convenient way to test this to confirm that adherence to `typing.IO[bytes]` contract is sufficient or if we need something additional from `io.BytesIO`)
  - for `**params`, the type specified must be the one of individual param values, not the whole dictionary ; based on existing codebase across all scrapers I assumed that `str` is sufficient.
  - `save_image` had to be changed as well to reflect changes made in `convert_image` 