### PR TITLE
Fix alpine tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Using openZIM Python bootstrap conventions (including hatch-openzim plugin) #120
-- Suuport for Python 3.12, drop Python 3.7 #118
-- Replace "iso-369" iso639-lang by "iso639-lang" library
+- Add support for Python 3.12, drop Python 3.7 support #118
+- Replace "iso-369" by "iso639-lang" library
+- Replace "file-magic" by "python-magic" library for Alpine Linux support and better maintenance
 - Rework the VideoWebmLow preset for faster encoding and smaller file size (preset has been bumped to version 2)
 - When reencoding a video, ffmpeg now uses only 1 CPU thread by default (new arg to `reencode` allows to override this default value)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ sudo apt install libmagic1 wget ffmpeg \
 apk add ffmpeg gifsicle libmagic wget libjpeg
 ```
 
+**Nota:** i18n features do not work on Alpine, see https://github.com/openzim/python-scraperlib/issues/134 ; there is one corresponding test which is failing.
+
 # Contribution
 
 This project adheres to openZIM's [Contribution Guidelines](https://github.com/openzim/overview/wiki/Contributing)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ sudo apt install libmagic1 wget ffmpeg \
     libharfbuzz-dev libfribidi-dev libxcb1-dev gifsicle
 ```
 
+## Alpine
+```
+apk add ffmpeg gifsicle libmagic wget libjpeg
+```
+
 # Contribution
 
 This project adheres to openZIM's [Contribution Guidelines](https://github.com/openzim/overview/wiki/Contributing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "colorthief==0.2.1",
   "python-resize-image>=1.1.19,<1.2",
   "Babel>=2.9,<3.0",
-  "python-magic>=0.4.24,<0.5",
+  "python-magic>=0.4.3,<0.5",
   "libzim>=3.4.0,<4.0",
   "beautifulsoup4>=4.9.3,<4.10", # upgrade to 4.10 and later to be done
   "lxml>=4.6.3,<4.10", # upgrade to 4.10 and later to be done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "colorthief==0.2.1",
   "python-resize-image>=1.1.19,<1.2",
   "Babel>=2.9,<3.0",
-  "file-magic>=0.4.0,<0.5",
+  "python-magic>=0.4.24,<0.5",
   "libzim>=3.4.0,<4.0",
   "beautifulsoup4>=4.9.3,<4.10", # upgrade to 4.10 and later to be done
   "lxml>=4.6.3,<4.10", # upgrade to 4.10 and later to be done

--- a/src/zimscraperlib/filesystem.py
+++ b/src/zimscraperlib/filesystem.py
@@ -31,7 +31,11 @@ def get_content_mimetype(content: bytes) -> str:
     """MIME Type of content retrieved from magic headers"""
 
     try:
-        detected_mime = magic.detect_from_content(content).mime_type
+        detected_mime = magic.from_buffer(content, mime=True)
+        if isinstance(
+            detected_mime, bytes
+        ):  # pragma: no cover (old python-magic versions where returning bytes)
+            detected_mime = detected_mime.decode()
     except UnicodeDecodeError:
         return "application/octet-stream"
     return MIME_OVERRIDES.get(detected_mime, detected_mime)

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -28,10 +28,10 @@ def test_content_mimetype_fallback(monkeypatch, undecodable_byte_stream):
     assert get_content_mimetype(undecodable_byte_stream) == "application/octet-stream"
 
     # mock then so we keep coverage on systems where magic works
-    def raising_magic(*args):  # noqa: ARG001
+    def raising_magic(*args, **kwargs):  # noqa: ARG001
         raise UnicodeDecodeError("nocodec", b"", 0, 1, "noreason")
 
-    monkeypatch.setattr(magic, "detect_from_content", raising_magic)
+    monkeypatch.setattr(magic, "from_buffer", raising_magic)
     assert get_content_mimetype(undecodable_byte_stream) == "application/octet-stream"
 
 

--- a/tests/video/test_video.py
+++ b/tests/video/test_video.py
@@ -130,7 +130,17 @@ def test_get_media_info(media_format, media, expected, test_files):
     with tempfile.TemporaryDirectory() as t:
         src = pathlib.Path(t).joinpath(media)
         shutil.copy2(test_files[media_format], src)
-        assert get_media_info(src) == expected
+        result = get_media_info(src)
+        assert result.keys() == expected.keys()
+        assert result["codecs"] == expected["codecs"]
+        assert result["duration"] == expected["duration"]
+        # for bitrate, we need to allow some variability, not all ffmpeg version are
+        # reporting the same values (e.g. Alpine Linux is reporting 3837275 instead of
+        # 3818365 for video.mp4) ; we allow 1% variability with following assertion
+        assert (
+            abs(100.0 * (result["bitrate"] - expected["bitrate"]) / expected["bitrate"])
+            < 1
+        )
 
 
 def test_preset_has_mime_and_ext():


### PR DESCRIPTION
Fix #114 (remaining part is now tracked in #134)

## Original comment

Partial fix of #114, the following test is still failing ; looks like on Alpine setlocale is never raising an error, see issue for details. I don't know if we accept to live with it or add a special detection for Alpine Linux which would skip the test.

```
FAILED tests/i18n/test_i18n.py::test_selocale_unsupported - Failed: DID NOT RAISE <class 'locale.Error'>
```

## Rationale

Some tests were failing on Alpine Linux + `file-magic` is not well maintained / not supporting Alpine Linux

## Changes
- replace `file-magic` by `python-magic` library, since the last one has support for Alpine + is better maintained
- add installation instruction for Alpine (maybe partial, at least sufficient for tests to pass)
- fix ffprobe test which was failing due to different bitrates being reported, we now allow 1% variability from expected value (we do not mind much about the exact bitrate)