### PR TITLE
Fix disable_metadata_checks behavior and fix StaticItem support of bytes content

### DIFF
--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -100,7 +100,7 @@ class Creator(libzim.writer.Creator):
     Use workaround_nocancel=False to disable the workaround.
 
     By default, all metadata are validated for compliance with openZIM guidelines and
-    conventions. Set disable_metadata_checks=False to disable this validation (you can
+    conventions. Set disable_metadata_checks=True to disable this validation (you can
     still do checks manually with the validation methods or your own logic).
     """
 
@@ -111,7 +111,7 @@ class Creator(libzim.writer.Creator):
         compression: Optional[str] = None,
         workaround_nocancel: Optional[bool] = True,  # noqa: FBT002
         ignore_duplicates: Optional[bool] = False,  # noqa: FBT002
-        disable_metadata_checks: bool = True,  # noqa: FBT001, FBT002
+        disable_metadata_checks: bool = False,  # noqa: FBT001, FBT002
     ):
         super().__init__(filename=filename)
         self._metadata = {}
@@ -148,7 +148,7 @@ class Creator(libzim.writer.Creator):
         if not all(self._metadata.get(key) for key in MANDATORY_ZIM_METADATA_KEYS):
             raise ValueError("Mandatory metadata are not all set.")
 
-        if self.disable_metadata_checks:
+        if not self.disable_metadata_checks:
             for name, value in self._metadata.items():
                 if value:
                     self.validate_metadata(name, value)
@@ -195,7 +195,7 @@ class Creator(libzim.writer.Creator):
         content: Union[str, bytes, datetime.date, datetime.datetime, Iterable[str]],
         mimetype: str = "text/plain;charset=UTF-8",
     ):
-        if self.disable_metadata_checks:
+        if not self.disable_metadata_checks:
             self.validate_metadata(name, content)
         if name == "Date" and isinstance(content, (datetime.date, datetime.datetime)):
             content = content.strftime("%Y-%m-%d").encode("UTF-8")

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -303,14 +303,6 @@ class Creator(libzim.writer.Creator):
         if should_compress is not None:
             hints[libzim.writer.Hint.COMPRESS] = should_compress
 
-        kwargs = {
-            "path": path,
-            "title": title or "",
-            "mimetype": mimetype,
-            "filepath": fpath if fpath is not None else "",
-            "hints": hints,
-            "content": content,
-        }
         if delete_fpath and fpath:
             cb = [delete_callback, fpath]
             if callback and callable(callback):
@@ -320,7 +312,16 @@ class Creator(libzim.writer.Creator):
             callback = tuple(cb)
 
         self.add_item(
-            StaticItem(**kwargs), callback=callback, duplicate_ok=duplicate_ok
+            StaticItem(
+                path=path,
+                title=title,
+                mimetype=mimetype,
+                filepath=fpath,
+                hints=hints,
+                content=content,
+            ),
+            callback=callback,
+            duplicate_ok=duplicate_ok,
         )
         return path
 

--- a/src/zimscraperlib/zim/items.py
+++ b/src/zimscraperlib/zim/items.py
@@ -34,13 +34,13 @@ class Item(libzim.writer.Item):
         **kwargs: Any,
     ):
         super().__init__()
-        if path:
+        if path is not None:
             kwargs["path"] = path
-        if title:
+        if title is not None:
             kwargs["title"] = title
-        if mimetype:
+        if mimetype is not None:
             kwargs["mimetype"] = mimetype
-        if hints:
+        if hints is not None:
             kwargs["hints"] = hints
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -81,11 +81,11 @@ class StaticItem(Item):
         hints: Optional[dict] = None,
         **kwargs: Any,
     ):
-        if content:
+        if content is not None:
             kwargs["content"] = content
-        if fileobj:
+        if fileobj is not None:
             kwargs["fileobj"] = fileobj
-        if filepath:
+        if filepath is not None:
             kwargs["filepath"] = filepath
         super().__init__(
             path=path, title=title, mimetype=mimetype, hints=hints, **kwargs
@@ -155,7 +155,7 @@ class URLItem(StaticItem):
         use_disk: Optional[bool] = None,
         **kwargs: Any,
     ):
-        if use_disk:
+        if use_disk is not None:
             kwargs["use_disk"] = use_disk
         super().__init__(
             path=path, title=title, mimetype=mimetype, hints=hints, **kwargs

--- a/src/zimscraperlib/zim/items.py
+++ b/src/zimscraperlib/zim/items.py
@@ -9,7 +9,7 @@ import pathlib
 import re
 import tempfile
 import urllib.parse
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import libzim.writer  # pyright: ignore
 
@@ -72,7 +72,7 @@ class StaticItem(Item):
 
     def __init__(
         self,
-        content: Optional[str] = None,
+        content: Optional[Union[str, bytes]] = None,
         fileobj: Optional[io.IOBase] = None,
         filepath: Optional[pathlib.Path] = None,
         path: Optional[str] = None,
@@ -95,6 +95,8 @@ class StaticItem(Item):
         # content was set manually
         content = getattr(self, "content", None)
         if content is not None:
+            if not isinstance(content, (str, bytes)):
+                raise AttributeError(f"Unexpected type for content: {type(content)}")
             return StringProvider(content=content, ref=self)
 
         # using a file-like object

--- a/src/zimscraperlib/zim/providers.py
+++ b/src/zimscraperlib/zim/providers.py
@@ -31,7 +31,7 @@ class FileProvider(libzim.writer.FileProvider):
 
 
 class StringProvider(libzim.writer.StringProvider):
-    def __init__(self, content: str, ref: Optional[object] = None):
+    def __init__(self, content: Union[str, bytes], ref: Optional[object] = None):
         super().__init__(content)
         self.ref = ref
 

--- a/tests/zim/conftest.py
+++ b/tests/zim/conftest.py
@@ -25,6 +25,26 @@ def html_str():
 
 
 @pytest.fixture(scope="function")
+def html_str_cn():
+    """sample HTML content with chinese characters"""
+    return """<html>
+<body>
+<ul>
+    <li><a href="download/toto.pdf">PDF doc in 汉字</a></li>
+    <li><a href="download/toto.txt">text file</a></li>
+    <li><a href="dest.html">HTML link</a></li>
+    <li><a href="no-extension">no ext link</a></li>
+    <li><a href="http://www.example.com/index/sample.html">external link</a></li>
+    <li><a href="mailto:example@example.com">e-mail link</a></li>
+    <li><a media="">no href link</a></li>
+<object data="download/toto.jpg" width="300" height="200"></object>
+<script src="assets/js/bootstrap/bootsrap.css?v=20190101"></script>
+</body>
+</html>
+"""
+
+
+@pytest.fixture(scope="function")
 def html_file(tmp_path, html_str):
     fpath = tmp_path / "test.html"
     with open(fpath, "w") as fh:

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -508,7 +508,7 @@ def test_check_metadata(tmp_path):
 
 
 def test_relax_metadata(tmp_path):
-    Creator(tmp_path, "", disable_metadata_checks=False).config_dev_metadata(
+    Creator(tmp_path, "", disable_metadata_checks=True).config_dev_metadata(
         Description="T" * 90
     ).start()
 

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -189,6 +189,17 @@ def test_add_item_for_delete_fail(tmp_path, png_image):
     assert reader.get_item("index")
 
 
+def test_add_item_empty_content(tmp_path):
+    fpath = tmp_path / "test.zim"
+    # test with incorrect content type
+    with Creator(fpath, "welcome").config_dev_metadata() as creator:
+        creator.add_item_for(
+            path="welcome",
+            title="hello",
+            content="",
+        )
+
+
 def test_add_item_for_unsupported_content_type(tmp_path):
     fpath = tmp_path / "test.zim"
     # test with incorrect content type


### PR DESCRIPTION
## Rationale

- libzim `StringProvider` supports both `bytes` and `str` types as `content` but `StaticItem` accepted only `str` in its type hint
  - this was detected while migrating `add_item_for` to use new `StaticItem` parameters
- last PR #135 was incorrect 🤦🏻
- using `main` code on kolibri showed an issue when the content passed to `add_item_for`/`StaticItem` is an empty string "" ; content is not set and `StaticItem` fails to know which content provider has to be used 

## Changes

- accept both `bytes` and `str` types as `content` in `StaticItem`
- accept both `bytes` and `str` types as `content` in scraperlib `StringProvider`
- check at runtime that content type is correct before passing it to the `StringProvider`
- reverse/fix logic of `disable_metadata_checks`
- always set item attributes when passed, even if 'False'/empty/whatever
- add sufficient tests, including the addition of a non-UTF8 item into the ZIM (as bytes) and its decoding
