### PR TITLE
simplify Optional and Union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Simplify type annotations by replacing Union and Optional with pipe character ("|") for improved readability and clarity
+
 ## [3.3.2] - 2024-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [libzim] `Archive.media_count`
 
 ### Changed
+
 - [libzim] `Archive.article_count` updated to match scraperlib's version
 - `Archive.article_counter` now deprecated. Now returns `Archive.article_count`
 - `Archive.media_counter` now deprecated. Now returns `Archive.media_count`
@@ -219,197 +220,194 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unreachable code removed in `imaging` module.
 - [tests] “Sanskrit” removed from tests as output not predicatble depending on plaftform.
 
-
 ## [1.4.3]
 
-* `zim.Archive.counters` wont fail on missing `Counter` metadata
+- `zim.Archive.counters` wont fail on missing `Counter` metadata
 
 ## [1.4.2]
 
-* Fixed leak in `zim.Archive`'s `.counters`
-* New `.get_text_metadata()` method on `zim.Archive` to save UTF-8 decoding
+- Fixed leak in `zim.Archive`'s `.counters`
+- New `.get_text_metadata()` method on `zim.Archive` to save UTF-8 decoding
 
 ## [1.4.1]
 
-* New `Counter` metadata based properties for Archive:
-  * `.counters`: parsed dict of the Counter metadata
-  * `.article_counter`: libkiwix's calculation for nb or article
-  * `.media_counter`: libkiwix's calculation for nb or media
-* Fixed `i18n.find_language_names()` failing on some languages
-* Added `uri` module with `rebuild_uri()`
-
+- New `Counter` metadata based properties for Archive:
+  - `.counters`: parsed dict of the Counter metadata
+  - `.article_counter`: libkiwix's calculation for nb or article
+  - `.media_counter`: libkiwix's calculation for nb or media
+- Fixed `i18n.find_language_names()` failing on some languages
+- Added `uri` module with `rebuild_uri()`
 
 ## [1.4.0]
 
-* Using new python-libzim based on libzim v7
-  * New Creator API
-  * Removed all namespace references
-  * Renamed `url` mentions to `path`
-  * Removed all links rewriting
-  * Removed Article/CSS/Binary seggreation
-  * Kept zimwriterfs mode (except it doesn't rewrite for namespaces)
-  * New `html` module for HTML document manipulations
-  * New callback system on `add_item_for()` and `add_item()`
-  * New Archive API with easier search/suggestions and content access
-* Changed download log level to DEBUG (was INFO)
-* `filesystem.get_file_mimetype` now passes bytes to libmagic instead of filename due to release issue in libmagic
-* safer `inputs.handle_user_provided_file` regarding input as str instead of Path
-* `image.presets` and `video.presets` now all includes `ext` and `mimetype` properties
-* Video convert log now DEBUG instead of INFO
-* Fixed `image.save_image()` saving to disk even when using a bytes stream
-* Fixed `image.transformation.resize_image()` when resizing a byte stream without a dst
+- Using new python-libzim based on libzim v7
+  - New Creator API
+  - Removed all namespace references
+  - Renamed `url` mentions to `path`
+  - Removed all links rewriting
+  - Removed Article/CSS/Binary seggreation
+  - Kept zimwriterfs mode (except it doesn't rewrite for namespaces)
+  - New `html` module for HTML document manipulations
+  - New callback system on `add_item_for()` and `add_item()`
+  - New Archive API with easier search/suggestions and content access
+- Changed download log level to DEBUG (was INFO)
+- `filesystem.get_file_mimetype` now passes bytes to libmagic instead of filename due to release issue in libmagic
+- safer `inputs.handle_user_provided_file` regarding input as str instead of Path
+- `image.presets` and `video.presets` now all includes `ext` and `mimetype` properties
+- Video convert log now DEBUG instead of INFO
+- Fixed `image.save_image()` saving to disk even when using a bytes stream
+- Fixed `image.transformation.resize_image()` when resizing a byte stream without a dst
 
 ## [1.3.6 (internal)]
 
 Intermediate release using unreleased libzim to support development of libzim7.
 Don't use it.
 
-* requesting newer libzim version (not released ATM)
-* New ZIM API for non-namespace libzim (v7)
-* updated all requirements
-* Fixed download test inconsistency
-* fix_ogvjs mostly useless: only allows webm types
-* exposing retry_adapter for refactoring
-* Changed download log level to DEBUG (was INFO)
-* guess more-defined mime from filename if magic says it's text
-* get_file_mimetype now passes bytes to libmagic
-* safer regarding input as str instead of Path
-* fixed static item for empty content
-* ext and mimetype properties for all presets
-* Video convert log now DEBUG instead of INFO
-* Added delete_fpath to add_item_for() and fixed StaticItem's auto remove
-* Updated badges for new repo name
+- requesting newer libzim version (not released ATM)
+- New ZIM API for non-namespace libzim (v7)
+- updated all requirements
+- Fixed download test inconsistency
+- fix_ogvjs mostly useless: only allows webm types
+- exposing retry_adapter for refactoring
+- Changed download log level to DEBUG (was INFO)
+- guess more-defined mime from filename if magic says it's text
+- get_file_mimetype now passes bytes to libmagic
+- safer regarding input as str instead of Path
+- fixed static item for empty content
+- ext and mimetype properties for all presets
+- Video convert log now DEBUG instead of INFO
+- Added delete_fpath to add_item_for() and fixed StaticItem's auto remove
+- Updated badges for new repo name
 
 ## [1.3.5]
 
-* add `stream_file()` to stream content from a URL into a file or a `BytesIO` object
-* deprecated `save_file()`
-* fixed `add_binary` when used without an fpath (#69)
-* deprecated `make_grayscale` option in image optimization
-* Added support for in-memory optimization for PNG, JPEG, and WebP images
-* allows enabling debug logs via ZIMSCRAPERLIB_DEBUG environ
+- add `stream_file()` to stream content from a URL into a file or a `BytesIO` object
+- deprecated `save_file()`
+- fixed `add_binary` when used without an fpath (#69)
+- deprecated `make_grayscale` option in image optimization
+- Added support for in-memory optimization for PNG, JPEG, and WebP images
+- allows enabling debug logs via ZIMSCRAPERLIB_DEBUG environ
 
 ## [1.3.4]
 
-* added `wait` option in `YoutubeDownloader` to allow parallelism while using context manager
-* do not use extension for finding format in `ensure_matches()` in `image.optimization` module
-* added `VideoWebmHigh` and `VideoMp4High` presets for high quality WebM and Mp4 convertion respectively
-* updated presets `WebpHigh`, `JpegMedium`, `JpegLow` and `PngMedium` in `image.presets`
-* `save_image` moved from `image` to `image.utils`
-* added `convert_image` `optimize_image` `resize_image` functions to `image` module
+- added `wait` option in `YoutubeDownloader` to allow parallelism while using context manager
+- do not use extension for finding format in `ensure_matches()` in `image.optimization` module
+- added `VideoWebmHigh` and `VideoMp4High` presets for high quality WebM and Mp4 convertion respectively
+- updated presets `WebpHigh`, `JpegMedium`, `JpegLow` and `PngMedium` in `image.presets`
+- `save_image` moved from `image` to `image.utils`
+- added `convert_image` `optimize_image` `resize_image` functions to `image` module
 
 ## [1.3.3]
 
-* added `YoutubeDownloader` to `download` to download YT videos using a capped nb of threads
+- added `YoutubeDownloader` to `download` to download YT videos using a capped nb of threads
 
 ## [1.3.2]
 
-* fixed rewriting of links with empty target
-* added support for image optimization using `zimscraperlib.image.optimization` for webp, gif, jpeg and png formats
-* added `format_for()` in `zimscraperlib.image.probing` to get PIL image format from the suffix
+- fixed rewriting of links with empty target
+- added support for image optimization using `zimscraperlib.image.optimization` for webp, gif, jpeg and png formats
+- added `format_for()` in `zimscraperlib.image.probing` to get PIL image format from the suffix
 
 ## [1.3.1]
 
-* replaced BeautifoulSoup parser in rewriting (`html.parser` –> `lxml`)
+- replaced BeautifoulSoup parser in rewriting (`html.parser` –> `lxml`)
 
 ## [1.3.0]
 
-* detect mimetypes from filenames for all text files
-* fixed non-filename based StaticArticle
-* enable rewriting of links in poster attribute of audio element
-* added find_language_in() and find_language_in_file() to get language from HTML content and HTML file respectively
-* add a mime mapping to deal with inconsistencies in mimetypes detected by magic on different platforms
-* convert_image signature changed:
-  * `target_format` positional argument removed. Replaced with optionnal `fmt` key of keyword arguments.
-  * `colorspace` optionnal positional argument removed. Replaced with optionnal `colorspace` key of keyword arguments.
-* prevent rewriting of links with special schemes `mailto`, 'tel', etc. in HTML links rewriting
-* replaced `imaging` module with exploded `image` module (`convertion`, `probing`, `transformation`)
-* changed `create_favicon()` param names (`source_image` -> `src`, `dest_ico` -> `dst`)
-* changed `save_image()` param names (`image` -> `src`)
-* changed `get_colors()` param names (`image_path` -> `src`)
-* changed `resize_image()` param names (`fpath` -> `src`)
+- detect mimetypes from filenames for all text files
+- fixed non-filename based StaticArticle
+- enable rewriting of links in poster attribute of audio element
+- added find_language_in() and find_language_in_file() to get language from HTML content and HTML file respectively
+- add a mime mapping to deal with inconsistencies in mimetypes detected by magic on different platforms
+- convert_image signature changed:
+  - `target_format` positional argument removed. Replaced with optionnal `fmt` key of keyword arguments.
+  - `colorspace` optionnal positional argument removed. Replaced with optionnal `colorspace` key of keyword arguments.
+- prevent rewriting of links with special schemes `mailto`, 'tel', etc. in HTML links rewriting
+- replaced `imaging` module with exploded `image` module (`convertion`, `probing`, `transformation`)
+- changed `create_favicon()` param names (`source_image` -> `src`, `dest_ico` -> `dst`)
+- changed `save_image()` param names (`image` -> `src`)
+- changed `get_colors()` param names (`image_path` -> `src`)
+- changed `resize_image()` param names (`fpath` -> `src`)
 
 ## [1.2.1]
 
-* fixed URL rewriting when running from /
-* added support for link rewriting in `<object>` element
-* prevent from raising error if element doesn't have the attribute with url
-* use non greedy match for CSS URL links (shortest string matching `url()` format)
-* fix namespace of target only if link doesn't have a netloc
+- fixed URL rewriting when running from /
+- added support for link rewriting in `<object>` element
+- prevent from raising error if element doesn't have the attribute with url
+- use non greedy match for CSS URL links (shortest string matching `url()` format)
+- fix namespace of target only if link doesn't have a netloc
 
 ## [1.2.0]
 
-* added UTF8 to constants
-* added mime_type discovery via magic (filesystem)
-* Added types: mime types guessing from file names
-* Revamped zim API
-  * Removed ZimInfo which role was tu hold metadata for zimwriterfs call
-  * Removed calling zimwriterfs binary but kept function name
-  * Added zim.filesystem: zimwriterfs-like creation from a build folder
-  * Added zim.creator: create files by manually adding each article
-  * Added zim.rewriting: tools to rewrite links/urls in HTML/CSS
-* add timeout and retries to save_file() and make it return headers
+- added UTF8 to constants
+- added mime_type discovery via magic (filesystem)
+- Added types: mime types guessing from file names
+- Revamped zim API
+  - Removed ZimInfo which role was tu hold metadata for zimwriterfs call
+  - Removed calling zimwriterfs binary but kept function name
+  - Added zim.filesystem: zimwriterfs-like creation from a build folder
+  - Added zim.creator: create files by manually adding each article
+  - Added zim.rewriting: tools to rewrite links/urls in HTML/CSS
+- add timeout and retries to save_file() and make it return headers
 
 ## [1.1.2]
 
-* fixed `convert_image()` which tried to use a closed file
+- fixed `convert_image()` which tried to use a closed file
 
 ## [1.1.1]
 
-* exposed reencode, Config and get_media_info in zimscraperlib.video
-* added save_image() and convert_image() in zimscraperlib.imaging
-* added support for upscaling in resize_image() via allow_upscaling
-* resize_image() now supports params given by user and preservs image colorspace
-* fixed tests for zimscraperlib.imaging
+- exposed reencode, Config and get_media_info in zimscraperlib.video
+- added save_image() and convert_image() in zimscraperlib.imaging
+- added support for upscaling in resize_image() via allow_upscaling
+- resize_image() now supports params given by user and preservs image colorspace
+- fixed tests for zimscraperlib.imaging
 
 ## [1.1.0]
 
-* added video module with reencode, presets, config builder and video file probing
-* `make_zim_file()` accepts extra kwargs for zimwriterfs
+- added video module with reencode, presets, config builder and video file probing
+- `make_zim_file()` accepts extra kwargs for zimwriterfs
 
 ## [1.0.6]
 
-* added translation support to i18n
+- added translation support to i18n
 
 ## [1.0.5]
 
-* added s3transfer to verbose dependencies list
-* changed default log format to include module name
+- added s3transfer to verbose dependencies list
+- changed default log format to include module name
 
 ## [1.0.4]
 
-* verbose dependencies (urllib3, boto3) now logged at WARNING level by default
-* ability to set verbose dependencies log level and add modules to the list
-* zimscraperlib's logging level now aligned with scraper's requested one
-
+- verbose dependencies (urllib3, boto3) now logged at WARNING level by default
+- ability to set verbose dependencies log level and add modules to the list
+- zimscraperlib's logging level now aligned with scraper's requested one
 
 ## [1.0.3]
 
-* fix_ogvjs_dist script more generic (#1)
-* updated zim to support other zimwriterfs params (#10)
-* more flexible requirements for requests dependency
+- fix_ogvjs_dist script more generic (#1)
+- updated zim to support other zimwriterfs params (#10)
+- more flexible requirements for requests dependency
 
 ## [1.0.2]
 
-* fixed return value of `get_language_details` on non-existent language
-* fixed crash on `resize_image` with method `height`
-* fixed root logger level (now DEBUG)
-* removed useless `console=True` `getLogger` param
-* completed tests (100% coverage)
-* added `./test` script for quick local testing
-* improved tox.ini
-* added `create_favicon` to generate a squared favicon
-* added `handle_user_provided_file` to handle user file/URL from param
+- fixed return value of `get_language_details` on non-existent language
+- fixed crash on `resize_image` with method `height`
+- fixed root logger level (now DEBUG)
+- removed useless `console=True` `getLogger` param
+- completed tests (100% coverage)
+- added `./test` script for quick local testing
+- improved tox.ini
+- added `create_favicon` to generate a squared favicon
+- added `handle_user_provided_file` to handle user file/URL from param
 
 ## [1.0.1]
 
-* fixed fix_ogvjs_dist
+- fixed fix_ogvjs_dist
 
 ## [1.0.0]
 
-* initial version providing
- * download: save_file, save_large_file
- * fix_ogvjs_dist
- * i18n: setlocale, get_language_details
- * imaging: get_colors, resize_image, is_hex_color
- * zim: ZimInfo, make_zim_file
+- initial version providing
+- download: save_file, save_large_file
+- fix_ogvjs_dist
+- i18n: setlocale, get_language_details
+- imaging: get_colors, resize_image, is_hex_color
+- zim: ZimInfo, make_zim_file

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -7,7 +7,7 @@ import io
 import pathlib
 import subprocess
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 import requests
 import yt_dlp as youtube_dl
@@ -21,7 +21,7 @@ class YoutubeDownloader:
     Shutdown method must be run explicitly to
     free any occupied resources"""
 
-    def __init__(self, threads: Optional[int] = 1) -> None:
+    def __init__(self, threads: int | None = 1) -> None:
         self.executor = ThreadPoolExecutor(max_workers=threads)
 
     def __enter__(self):
@@ -41,9 +41,9 @@ class YoutubeDownloader:
     def download(
         self,
         url: str,
-        options: Optional[dict],
-        wait: Optional[bool] = True,  # noqa: FBT002
-    ) -> Union[bool, Future]:
+        options: dict | None,
+        wait: bool | None = True,  # noqa: FBT002
+    ) -> bool | Future:
         """Downloads video using initialized executor.
 
         url: URL or Video ID
@@ -65,8 +65,8 @@ class YoutubeDownloader:
 
 
 class YoutubeConfig(dict):
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {}
-    defaults: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {}
+    defaults: ClassVar[dict[str, str | bool | int | None]] = {
         "writethumbnail": True,
         "write_all_thumbnails": True,
         "writesubtitles": True,
@@ -88,8 +88,8 @@ class YoutubeConfig(dict):
     @classmethod
     def get_options(
         cls,
-        target_dir: Optional[pathlib.Path] = None,
-        filepath: Optional[pathlib.Path] = None,
+        target_dir: pathlib.Path | None = None,
+        filepath: pathlib.Path | None = None,
         **options,
     ):
         if "outtmpl" not in options:
@@ -109,14 +109,14 @@ class YoutubeConfig(dict):
 
 
 class BestWebm(YoutubeConfig):
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "preferredcodec": "webm",
         "format": "best[ext=webm]/bestvideo[ext=webm]+bestaudio[ext=webm]/best",
     }
 
 
 class BestMp4(YoutubeConfig):
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "preferredcodec": "mp4",
         "format": "best[ext=mp4]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best",
     }
@@ -142,7 +142,7 @@ def save_large_file(url: str, fpath: pathlib.Path) -> None:
 
 
 def _get_retry_adapter(
-    max_retries: Optional[int] = 5,
+    max_retries: int | None = 5,
 ) -> requests.adapters.BaseAdapter:  # pyright: ignore
     retries = requests.packages.urllib3.util.retry.Retry(  # pyright: ignore
         total=max_retries,  # total number of retries
@@ -164,7 +164,7 @@ def _get_retry_adapter(
     return requests.adapters.HTTPAdapter(max_retries=retries)  # pyright: ignore
 
 
-def get_session(max_retries: Optional[int] = 5) -> requests.Session:
+def get_session(max_retries: int | None = 5) -> requests.Session:
     """Session to hold cookies and connection pool together"""
     session = requests.Session()
     session.mount("http", _get_retry_adapter(max_retries))  # tied to http and https
@@ -173,14 +173,14 @@ def get_session(max_retries: Optional[int] = 5) -> requests.Session:
 
 def stream_file(
     url: str,
-    fpath: Optional[pathlib.Path] = None,
-    byte_stream: Optional[io.BytesIO] = None,
-    block_size: Optional[int] = 1024,
-    proxies: Optional[dict] = None,
-    only_first_block: Optional[bool] = False,  # noqa: FBT002
-    max_retries: Optional[int] = 5,
-    headers: Optional[dict[str, str]] = None,
-    session: Optional[requests.Session] = None,
+    fpath: pathlib.Path | None = None,
+    byte_stream: io.BytesIO | None = None,
+    block_size: int | None = 1024,
+    proxies: dict | None = None,
+    only_first_block: bool | None = False,  # noqa: FBT002
+    max_retries: int | None = 5,
+    headers: dict[str, str] | None = None,
+    session: requests.Session | None = None,
 ) -> tuple[int, requests.structures.CaseInsensitiveDict]:  # pyright: ignore
     """Stream data from a URL to either a BytesIO object or a file
     Arguments -

--- a/src/zimscraperlib/filesystem.py
+++ b/src/zimscraperlib/filesystem.py
@@ -5,10 +5,12 @@
 
     Shortcuts to retrieve mime type using magic"""
 
+from __future__ import annotations
+
 import os
 import pathlib
 from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any
 
 import magic
 
@@ -43,8 +45,8 @@ def get_content_mimetype(content: bytes) -> str:
 
 
 def delete_callback(
-    fpath: Union[str, pathlib.Path],
-    callback: Optional[Callable] = None,
+    fpath: str | pathlib.Path,
+    callback: Callable | None = None,
     *callback_args: Any,
 ):
     """helper deleting passed filepath, optionnaly calling an additional callback"""

--- a/src/zimscraperlib/fix_ogvjs_dist.py
+++ b/src/zimscraperlib/fix_ogvjs_dist.py
@@ -9,13 +9,12 @@ from __future__ import annotations
 import logging
 import pathlib
 import sys
-from typing import Union
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-def fix_source_dir(source_vendors_path: Union[pathlib.Path, str]):
+def fix_source_dir(source_vendors_path: pathlib.Path | str):
     """update ogvjs plugin to trigger on webm mimetype"""
     root = pathlib.Path(source_vendors_path)
     logger.info("fixing videosjs-ogvjs.js")

--- a/src/zimscraperlib/html.py
+++ b/src/zimscraperlib/html.py
@@ -2,16 +2,17 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 """ Tools to work with HTML contents """
+from __future__ import annotations
 
 import pathlib
-from typing import BinaryIO, TextIO, Union
+from typing import BinaryIO, TextIO
 
 from bs4 import BeautifulSoup
 
 from zimscraperlib.types import ARTICLE_MIME
 
 
-def find_title_in(content: Union[str, BinaryIO, TextIO], mime_type: str) -> str:
+def find_title_in(content: str | BinaryIO | TextIO, mime_type: str) -> str:
     """Extracted title from HTML content
 
     blank on failure to extract and non-HTML files"""
@@ -32,7 +33,7 @@ def find_title_in_file(fpath: pathlib.Path, mime_type: str) -> str:
         return ""
 
 
-def find_language_in(content: Union[str, BinaryIO, TextIO], mime_type: str) -> str:
+def find_language_in(content: str | BinaryIO | TextIO, mime_type: str) -> str:
     """Extracted language from HTML content
 
     blank on failure to extract and non-HTML files"""

--- a/src/zimscraperlib/i18n.py
+++ b/src/zimscraperlib/i18n.py
@@ -7,7 +7,6 @@ import gettext
 import locale
 import pathlib
 import re
-from typing import Optional, Union
 
 import babel
 import iso639
@@ -60,7 +59,7 @@ def setlocale(root_dir: pathlib.Path, locale_name: str):
     return Locale.setup(root_dir / "locale", locale_name)
 
 
-def get_iso_lang_data(lang: str) -> tuple[dict, Union[dict, None]]:
+def get_iso_lang_data(lang: str) -> tuple[dict, dict | None]:
     """ISO-639-x languages details for lang. Raises NotFound
 
     Included keys: iso-639-1, iso-639-2b, iso-639-2t, iso-639-3, iso-639-5
@@ -113,9 +112,7 @@ def get_iso_lang_data(lang: str) -> tuple[dict, Union[dict, None]]:
     return lang_data, None
 
 
-def find_language_names(
-    query: str, lang_data: Optional[dict] = None
-) -> tuple[str, str]:
+def find_language_names(query: str, lang_data: dict | None = None) -> tuple[str, str]:
     """(native, english) language names for lang with help from language_details dict
 
     Falls back to English name if available or query if not"""
@@ -152,7 +149,7 @@ def update_with_macro(lang_data: dict, macro_data: dict):
 
 
 def get_language_details(
-    query: str, failsafe: Optional[bool] = False  # noqa: FBT002
+    query: str, failsafe: bool | None = False  # noqa: FBT002
 ) -> dict:
     """language details dict from query.
 

--- a/src/zimscraperlib/image/convertion.py
+++ b/src/zimscraperlib/image/convertion.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+from __future__ import annotations
+
 import io
 import pathlib
-from typing import Union
 
 import PIL
 
@@ -14,8 +15,8 @@ from zimscraperlib.image.utils import save_image
 
 
 def convert_image(
-    src: Union[pathlib.Path, io.BytesIO],
-    dst: Union[pathlib.Path, io.BytesIO],
+    src: pathlib.Path | io.BytesIO,
+    dst: pathlib.Path | io.BytesIO,
     **params: str,
 ) -> None:
     """convert an image file from one format to another

--- a/src/zimscraperlib/image/optimization.py
+++ b/src/zimscraperlib/image/optimization.py
@@ -28,7 +28,6 @@ import io
 import os
 import pathlib
 import subprocess
-from typing import Optional, Union
 
 import piexif
 from optimize_images.img_aux_processing import do_reduce_colors, rebuild_palette
@@ -52,15 +51,15 @@ def ensure_matches(
 
 
 def optimize_png(
-    src: Union[pathlib.Path, io.BytesIO],
-    dst: Optional[pathlib.Path] = None,
-    reduce_colors: Optional[bool] = False,  # noqa: FBT002
-    max_colors: Optional[int] = 256,
-    fast_mode: Optional[bool] = True,  # noqa: FBT002
-    remove_transparency: Optional[bool] = False,  # noqa: FBT002
-    background_color: Optional[tuple[int, int, int]] = (255, 255, 255),
+    src: pathlib.Path | io.BytesIO,
+    dst: pathlib.Path | None = None,
+    reduce_colors: bool | None = False,  # noqa: FBT002
+    max_colors: int | None = 256,
+    fast_mode: bool | None = True,  # noqa: FBT002
+    remove_transparency: bool | None = False,  # noqa: FBT002
+    background_color: tuple[int, int, int] | None = (255, 255, 255),
     **options,  # noqa: ARG001
-) -> Union[pathlib.Path, io.BytesIO]:
+) -> pathlib.Path | io.BytesIO:
     """method to optimize PNG files using a pure python external optimizer
 
     Arguments:
@@ -99,13 +98,13 @@ def optimize_png(
 
 
 def optimize_jpeg(
-    src: Union[pathlib.Path, io.BytesIO],
-    dst: Optional[pathlib.Path] = None,
-    quality: Optional[int] = 85,
-    fast_mode: Optional[bool] = True,  # noqa: FBT002
-    keep_exif: Optional[bool] = True,  # noqa: FBT002
+    src: pathlib.Path | io.BytesIO,
+    dst: pathlib.Path | None = None,
+    quality: int | None = 85,
+    fast_mode: bool | None = True,  # noqa: FBT002
+    keep_exif: bool | None = True,  # noqa: FBT002
     **options,  # noqa: ARG001
-) -> Union[pathlib.Path, io.BytesIO]:
+) -> pathlib.Path | io.BytesIO:
     """method to optimize JPEG files using a pure python external optimizer
     quality: JPEG quality (integer between 1 and 100)
         values: 50 | 55 | 35 | 100 | XX
@@ -169,13 +168,13 @@ def optimize_jpeg(
 
 
 def optimize_webp(
-    src: Union[pathlib.Path, io.BytesIO],
-    dst: Optional[pathlib.Path] = None,
-    lossless: Optional[bool] = False,  # noqa: FBT002
-    quality: Optional[int] = 60,
-    method: Optional[int] = 6,
+    src: pathlib.Path | io.BytesIO,
+    dst: pathlib.Path | None = None,
+    lossless: bool | None = False,  # noqa: FBT002
+    quality: int | None = 60,
+    method: int | None = 6,
     **options,  # noqa: ARG001
-) -> Union[pathlib.Path, io.BytesIO]:
+) -> pathlib.Path | io.BytesIO:
     """method to optimize WebP using Pillow options
     lossless: Whether to use lossless compression (boolean)
         values: True | False
@@ -214,11 +213,11 @@ def optimize_webp(
 def optimize_gif(
     src: pathlib.Path,
     dst: pathlib.Path,
-    optimize_level: Optional[int] = 1,
-    lossiness: Optional[int] = None,
-    interlace: Optional[bool] = True,  # noqa: FBT002
-    no_extensions: Optional[bool] = True,  # noqa: FBT002
-    max_colors: Optional[int] = None,
+    optimize_level: int | None = 1,
+    lossiness: int | None = None,
+    interlace: bool | None = True,  # noqa: FBT002
+    no_extensions: bool | None = True,  # noqa: FBT002
+    max_colors: int | None = None,
     **options,  # noqa: ARG001
 ) -> pathlib.Path:
     """method to optimize GIFs using gifsicle >= 1.92
@@ -267,8 +266,8 @@ def optimize_gif(
 def optimize_image(
     src: pathlib.Path,
     dst: pathlib.Path,
-    delete_src: Optional[bool] = False,  # noqa: FBT002
-    convert: Optional[Union[bool, str]] = False,  # noqa: FBT002
+    delete_src: bool | None = False,  # noqa: FBT002
+    convert: bool | str | None = False,  # noqa: FBT002
     **options,
 ) -> bool:  # pyright: ignore
     """Optimize image, automatically selecting correct optimizer

--- a/src/zimscraperlib/image/presets.py
+++ b/src/zimscraperlib/image/presets.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 """ presets for ImageOptimizer in zimscraperlib.image.optimization module """
 
@@ -22,7 +22,7 @@ class WebpLow:
     ext = "webp"
     mimetype = f"{preset_type}/webp"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "lossless": False,
         "quality": 40,
         "method": 6,
@@ -41,7 +41,7 @@ class WebpMedium:
     ext = "webp"
     mimetype = f"{preset_type}/webp"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "lossless": False,
         "quality": 50,
         "method": 6,
@@ -60,7 +60,7 @@ class WebpHigh:
     ext = "webp"
     mimetype = f"{preset_type}/webp"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "lossless": False,
         "quality": 90,
         "method": 6,
@@ -81,7 +81,7 @@ class GifLow:
     ext = "gif"
     mimetype = f"{preset_type}/gif"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "optimize_level": 3,
         "max_colors": 256,
         "lossiness": 80,
@@ -104,7 +104,7 @@ class GifMedium:
     ext = "gif"
     mimetype = f"{preset_type}/gif"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "optimize_level": 3,
         "lossiness": 20,
         "no_extensions": True,
@@ -126,7 +126,7 @@ class GifHigh:
     ext = "gif"
     mimetype = f"{preset_type}/gif"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "optimize_level": 2,
         "lossiness": None,
         "no_extensions": True,
@@ -145,7 +145,7 @@ class PngLow:
     ext = "png"
     mimetype = f"{preset_type}/png"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "reduce_colors": True,
         "remove_transparency": False,
         "max_colors": 256,
@@ -164,7 +164,7 @@ class PngMedium:
     ext = "png"
     mimetype = f"{preset_type}/png"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "reduce_colors": False,
         "remove_transparency": False,
         "fast_mode": False,
@@ -182,7 +182,7 @@ class PngHigh:
     ext = "png"
     mimetype = f"{preset_type}/png"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "reduce_colors": False,
         "remove_transparency": False,
         "fast_mode": True,
@@ -201,7 +201,7 @@ class JpegLow:
     ext = "png"
     mimetype = f"{preset_type}/png"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "quality": 45,
         "keep_exif": False,
         "fast_mode": True,
@@ -220,7 +220,7 @@ class JpegMedium:
     ext = "jpg"
     mimetype = f"{preset_type}/jpeg"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "quality": 65,
         "keep_exif": False,
         "fast_mode": True,
@@ -239,7 +239,7 @@ class JpegHigh:
     ext = "jpg"
     mimetype = f"{preset_type}/jpeg"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "quality": 80,
         "keep_exif": True,
         "fast_mode": True,

--- a/src/zimscraperlib/image/probing.py
+++ b/src/zimscraperlib/image/probing.py
@@ -7,14 +7,13 @@ import colorsys
 import io
 import pathlib
 import re
-from typing import Optional, Union
 
 import colorthief
 import PIL.Image
 
 
 def get_colors(
-    src: pathlib.Path, use_palette: Optional[bool] = True  # noqa: FBT002
+    src: pathlib.Path, use_palette: bool | None = True  # noqa: FBT002
 ) -> tuple[str, str]:
     """(main, secondary) HTML color codes from an image path"""
 
@@ -53,7 +52,7 @@ def is_hex_color(text: str) -> bool:
 
 
 def format_for(
-    src: Union[pathlib.Path, io.BytesIO],
+    src: pathlib.Path | io.BytesIO,
     from_suffix: bool = True,  # noqa: FBT001, FBT002
 ) -> str:
     """Pillow format of a given filename, either Pillow-detected or from suffix"""
@@ -71,9 +70,9 @@ def format_for(
 
 
 def is_valid_image(
-    image: Union[pathlib.Path, io.IOBase, bytes],
+    image: pathlib.Path | io.IOBase | bytes,
     imformat: str,
-    size: Optional[tuple[int, int]] = None,
+    size: tuple[int, int] | None = None,
 ) -> bool:
     """whether image is a valid imformat (PNG) image, optionnaly of requested size"""
     if isinstance(image, bytes):

--- a/src/zimscraperlib/image/transformation.py
+++ b/src/zimscraperlib/image/transformation.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+from __future__ import annotations
+
 import io
 import pathlib
-from typing import Optional, Union
 
 import PIL
 from resizeimage import resizeimage
@@ -13,12 +14,12 @@ from zimscraperlib.image.utils import save_image
 
 
 def resize_image(
-    src: Union[pathlib.Path, io.BytesIO],
+    src: pathlib.Path | io.BytesIO,
     width: int,
-    height: Optional[int] = None,
-    dst: Optional[Union[pathlib.Path, io.BytesIO]] = None,
-    method: Optional[str] = "width",
-    allow_upscaling: Optional[bool] = True,  # noqa: FBT002
+    height: int | None = None,
+    dst: pathlib.Path | io.BytesIO | None = None,
+    method: str | None = "width",
+    allow_upscaling: bool | None = True,  # noqa: FBT002
     **params: str,
 ) -> None:
     """resize an image to requested dimensions

--- a/src/zimscraperlib/image/utils.py
+++ b/src/zimscraperlib/image/utils.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4 nu
+from __future__ import annotations
 
 import io
 import pathlib
-from typing import Optional, Union
 
 from PIL import Image
 
 
 def save_image(
     src: Image,  # pyright: ignore
-    dst: Union[pathlib.Path, io.BytesIO],
-    fmt: Optional[str] = None,
+    dst: pathlib.Path | io.BytesIO,
+    fmt: str | None = None,
     **params: str,
 ) -> None:
     """PIL.Image.save() wrapper setting default parameters"""

--- a/src/zimscraperlib/inputs.py
+++ b/src/zimscraperlib/inputs.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import pathlib
 import shutil
 import tempfile
-from typing import Optional, Union
 
 from zimscraperlib import logger
 from zimscraperlib.constants import DEFAULT_USER_AGENT
@@ -20,12 +19,12 @@ from zimscraperlib.download import stream_file
 
 
 def handle_user_provided_file(
-    source: Optional[Union[pathlib.Path, str]] = None,
-    dest: Optional[pathlib.Path] = None,
-    in_dir: Optional[pathlib.Path] = None,
+    source: pathlib.Path | str | None = None,
+    dest: pathlib.Path | None = None,
+    in_dir: pathlib.Path | None = None,
     nocopy: bool = False,  # noqa: FBT001, FBT002
-    user_agent: Optional[str] = DEFAULT_USER_AGENT,
-) -> Union[pathlib.Path, None]:
+    user_agent: str | None = DEFAULT_USER_AGENT,
+) -> pathlib.Path | None:
     """path to downloaded or copied a user provided file (URL or path)
 
     args:
@@ -63,9 +62,9 @@ def handle_user_provided_file(
 
 def compute_descriptions(
     default_description: str,
-    user_description: Optional[str],
-    user_long_description: Optional[str],
-) -> tuple[str, Optional[str]]:
+    user_description: str | None,
+    user_long_description: str | None,
+) -> tuple[str, str | None]:
     """Computes short and long descriptions compliant with ZIM standard.
 
     Based on provided parameters, the function computes a short and a long description

--- a/src/zimscraperlib/logging.py
+++ b/src/zimscraperlib/logging.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+from __future__ import annotations
+
 import io
 import logging
 import pathlib
 import sys
 from collections.abc import Iterable
 from logging.handlers import RotatingFileHandler
-from typing import Optional
 
 from zimscraperlib.constants import NAME
 
@@ -17,16 +18,16 @@ VERBOSE_DEPENDENCIES = ["urllib3", "PIL", "boto3", "botocore", "s3transfer"]
 
 def getLogger(  # noqa: N802
     name: str,
-    level: Optional[int] = logging.INFO,
-    console: Optional[io.TextIOBase] = sys.stdout,  # pyright: ignore
-    log_format: Optional[str] = DEFAULT_FORMAT,
-    file: Optional[pathlib.Path] = False,  # noqa: FBT002  # pyright: ignore
-    file_level: Optional[int] = None,
-    file_format: Optional[str] = None,
-    file_max: Optional[int] = 2**20,
-    file_nb_backup: Optional[int] = 1,
-    deps_level: Optional[int] = logging.WARNING,  # noqa: ARG001
-    additional_deps: Optional[Iterable] = None,
+    level: int | None = logging.INFO,
+    console: io.TextIOBase | None = sys.stdout,  # pyright: ignore
+    log_format: str | None = DEFAULT_FORMAT,
+    file: pathlib.Path | None = False,  # noqa: FBT002  # pyright: ignore
+    file_level: int | None = None,
+    file_format: str | None = None,
+    file_max: int | None = 2**20,
+    file_nb_backup: int | None = 1,
+    deps_level: int | None = logging.WARNING,  # noqa: ARG001
+    additional_deps: Iterable | None = None,
 ):
     """configured logger for most usages
 

--- a/src/zimscraperlib/misc.py
+++ b/src/zimscraperlib/misc.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 """ Miscelaneous utils"""
 
-from typing import Optional
 
-
-def first(*args: Optional[object]) -> object:
+def first(*args: object | None) -> object:
     """first non-None value from *args ; fallback to empty string"""
     return next((item for item in args if item is not None), "")

--- a/src/zimscraperlib/misc.py
+++ b/src/zimscraperlib/misc.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """ Miscelaneous utils"""
+
+from __future__ import annotations
 
 
 def first(*args: object | None) -> object:

--- a/src/zimscraperlib/types.py
+++ b/src/zimscraperlib/types.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import mimetypes
 import pathlib
-from typing import Optional, Union
 
 ARTICLE_MIME: str = "text/html"
 FALLBACK_MIME: str = "application/octet-stream"
@@ -38,8 +37,8 @@ FONT_MIMES: list[str] = [
 
 
 def get_mime_for_name(
-    filename: Union[str, pathlib.Path],
-    fallback: Optional[str] = FALLBACK_MIME,
+    filename: str | pathlib.Path,
+    fallback: str | None = FALLBACK_MIME,
     no_ext_to=ARTICLE_MIME,
 ) -> str:
     """MIME-Type string from a filename

--- a/src/zimscraperlib/uri.py
+++ b/src/zimscraperlib/uri.py
@@ -1,7 +1,8 @@
 """ URI handling module"""
 
+from __future__ import annotations
+
 import urllib.parse
-from typing import Optional, Union
 
 from zimscraperlib import logger
 from zimscraperlib.misc import first
@@ -9,15 +10,15 @@ from zimscraperlib.misc import first
 
 def rebuild_uri(
     uri: urllib.parse.ParseResult,
-    scheme: Optional[str] = None,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
-    hostname: Optional[str] = None,
-    port: Optional[Union[str, int]] = None,
-    path: Optional[str] = None,
-    params: Optional[str] = None,
-    query: Optional[str] = None,
-    fragment: Optional[str] = None,
+    scheme: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    hostname: str | None = None,
+    port: str | int | None = None,
+    path: str | None = None,
+    params: str | None = None,
+    query: str | None = None,
+    fragment: str | None = None,
     failsafe: bool = False,  # noqa: FBT001, FBT002
 ) -> urllib.parse.ParseResult:
     """new ParseResult named tuple from uri with requested part updated"""

--- a/src/zimscraperlib/video/config.py
+++ b/src/zimscraperlib/video/config.py
@@ -3,18 +3,18 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 
 class Config(dict):
     VERSION = 1
     ext = "dat"
     mimetype = "application/data"
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {}
-    defaults: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {}
+    defaults: ClassVar[dict[str, str | bool | int | None]] = {
         "-max_muxing_queue_size": "9999"
     }
-    mapping: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    mapping: ClassVar[dict[str, str | bool | int | None]] = {
         "video_codec": "-codec:v",
         "audio_codec": "-codec:a",
         "max_video_bitrate": "-maxrate",

--- a/src/zimscraperlib/video/encoding.py
+++ b/src/zimscraperlib/video/encoding.py
@@ -8,7 +8,6 @@ import shutil
 import subprocess
 import tempfile
 from copy import deepcopy
-from typing import Optional
 
 from zimscraperlib import logger
 from zimscraperlib.logging import nicer_args_join
@@ -18,7 +17,7 @@ def _build_ffmpeg_args(
     src_path: pathlib.Path,
     tmp_path: pathlib.Path,
     ffmpeg_args: list[str],
-    threads: Optional[int],
+    threads: int | None,
 ) -> list[str]:
     ffmpeg_args = deepcopy(ffmpeg_args)
     if threads:
@@ -45,7 +44,7 @@ def reencode(
     delete_src=False,  # noqa: FBT002
     with_process=False,  # noqa: FBT002
     failsafe=True,  # noqa: FBT002
-    threads: Optional[int] = 1,
+    threads: int | None = 1,
 ):
     """Runs ffmpeg with given ffmpeg_args
 

--- a/src/zimscraperlib/video/presets.py
+++ b/src/zimscraperlib/video/presets.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from zimscraperlib.video.config import Config
 
@@ -22,7 +22,7 @@ class VoiceMp3Low(Config):
     ext = "mp3"
     mimetype = "audio/mp3"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "-vn": "",  # remove video stream
         "-codec:a": "mp3",  # audio codec
         "-ar": "44100",  # audio sampling rate
@@ -42,7 +42,7 @@ class VideoWebmLow(Config):
     ext = "webm"
     mimetype = f"{preset_type}/webm"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "-codec:v": "libvpx",  # video codec
         "-quality": "best",  # codec preset
         "-b:v": "128k",  # Adjust quantizer within min/max to target this bitrate
@@ -68,7 +68,7 @@ class VideoMp4Low(Config):
     ext = "mp4"
     mimetype = f"{preset_type}/mp4"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "-codec:v": "h264",  # video codec
         "-b:v": "300k",  # target video bitrate
         "-maxrate": "300k",  # max video bitrate
@@ -93,7 +93,7 @@ class VideoWebmHigh(Config):
     ext = "webm"
     mimetype = f"{preset_type}/webm"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "-codec:v": "libvpx",  # video codec
         "-codec:a": "libvorbis",  # audio codec
         "-crf": "25",  # constant quality, lower value gives better qual and larger size
@@ -111,7 +111,7 @@ class VideoMp4High(Config):
     ext = "mp4"
     mimetype = f"{preset_type}/mp4"
 
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {
+    options: ClassVar[dict[str, str | bool | int | None]] = {
         "-codec:v": "h264",  # video codec
         "-codec:a": "aac",  # audio codec
         "-crf": "20",  # constant quality, lower value gives better qual and larger size

--- a/src/zimscraperlib/zim/_libkiwix.py
+++ b/src/zimscraperlib/zim/_libkiwix.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import io
 from collections import namedtuple
-from typing import Dict, Optional
+from typing import Dict
 
 MimetypeAndCounter = namedtuple("MimetypeAndCounter", ["mimetype", "value"])
 CounterMap = Dict[
@@ -24,7 +24,7 @@ CounterMap = Dict[
 ]
 
 
-def getline(src: io.StringIO, delim: Optional[bool] = None) -> tuple[bool, str]:
+def getline(src: io.StringIO, delim: bool | None = None) -> tuple[bool, str]:
     """C++ stdlib getline() ~clone
 
     Reads `src` until it finds `delim`.

--- a/src/zimscraperlib/zim/archive.py
+++ b/src/zimscraperlib/zim/archive.py
@@ -12,7 +12,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Optional
 
 import libzim.reader  # pyright: ignore
 import libzim.search  # Query, Searcher  # pyright: ignore
@@ -71,7 +70,7 @@ class Archive(libzim.reader.Archive):
         return bytes(self.get_item(path).content)
 
     def get_suggestions(
-        self, query: str, start: int = 0, end: Optional[int] = None
+        self, query: str, start: int = 0, end: int | None = None
     ) -> Iterable[str]:
         """paths iterator over suggestion matches for query"""
         suggestion = libzim.suggestion.SuggestionSearcher(self).suggest(query)
@@ -85,7 +84,7 @@ class Archive(libzim.reader.Archive):
         return suggestion.getEstimatedMatches()
 
     def get_search_results(
-        self, query: str, start: int = 0, end: Optional[int] = None
+        self, query: str, start: int = 0, end: int | None = None
     ) -> Iterable[str]:
         """paths iterator over search results for query"""
         search = libzim.search.Searcher(self).search(

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -24,7 +24,7 @@ import pathlib
 import re
 import weakref
 from collections.abc import Callable, Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 import libzim.writer  # pyright: ignore
 
@@ -64,9 +64,9 @@ DUPLICATE_EXC_STR = re.compile(
 
 def mimetype_for(
     path: str,
-    content: Optional[Union[bytes, str]] = None,
-    fpath: Optional[pathlib.Path] = None,
-    mimetype: Optional[str] = None,
+    content: bytes | str | None = None,
+    fpath: pathlib.Path | None = None,
+    mimetype: str | None = None,
 ) -> str:
     """mimetype as provided or guessed from fpath, path or content"""
     if not mimetype:
@@ -110,9 +110,9 @@ class Creator(libzim.writer.Creator):
         self,
         filename: pathlib.Path,
         main_path: str,
-        compression: Optional[str] = None,
-        workaround_nocancel: Optional[bool] = True,  # noqa: FBT002
-        ignore_duplicates: Optional[bool] = False,  # noqa: FBT002
+        compression: str | None = None,
+        workaround_nocancel: bool | None = True,  # noqa: FBT002
+        ignore_duplicates: bool | None = False,  # noqa: FBT002
         disable_metadata_checks: bool = False,  # noqa: FBT001, FBT002
     ):
         super().__init__(filename=filename)
@@ -134,7 +134,7 @@ class Creator(libzim.writer.Creator):
         self.disable_metadata_checks = disable_metadata_checks
 
     def config_indexing(
-        self, indexing: bool, language: Optional[str] = None  # noqa: FBT001
+        self, indexing: bool, language: str | None = None  # noqa: FBT001
     ):
         """Toggle full-text and title indexing of entries
 
@@ -172,7 +172,7 @@ class Creator(libzim.writer.Creator):
     def validate_metadata(
         self,
         name: str,
-        value: Union[bytes, str, datetime.datetime, datetime.date, Iterable[str]],
+        value: bytes | str | datetime.datetime | datetime.date | Iterable[str],
     ):
         """Ensures metadata value for name is conform with the openZIM spec on Metadata
 
@@ -194,7 +194,7 @@ class Creator(libzim.writer.Creator):
     def add_metadata(
         self,
         name: str,
-        content: Union[str, bytes, datetime.date, datetime.datetime, Iterable[str]],
+        content: str | bytes | datetime.date | datetime.datetime | Iterable[str],
         mimetype: str = "text/plain;charset=UTF-8",
     ):
         if not self.disable_metadata_checks:
@@ -217,17 +217,17 @@ class Creator(libzim.writer.Creator):
         Language: str,  # noqa: N803
         Title: str,  # noqa: N803
         Description: str,  # noqa: N803
-        LongDescription: Optional[str] = None,  # noqa: N803
+        LongDescription: str | None = None,  # noqa: N803
         Creator: str,  # noqa: N803
         Publisher: str,  # noqa: N803
-        Date: Union[datetime.datetime, datetime.date, str],  # noqa: N803
+        Date: datetime.datetime | datetime.date | str,  # noqa: N803
         Illustration_48x48_at_1: bytes,  # noqa: N803
-        Tags: Optional[Union[Iterable[str], str]] = None,  # noqa: N803
-        Scraper: Optional[str] = None,  # noqa: N803
-        Flavour: Optional[str] = None,  # noqa: N803
-        Source: Optional[str] = None,  # noqa: N803
-        License: Optional[str] = None,  # noqa: N803
-        Relation: Optional[str] = None,  # noqa: N803
+        Tags: Iterable[str] | str | None = None,  # noqa: N803
+        Scraper: str | None = None,  # noqa: N803
+        Flavour: str | None = None,  # noqa: N803
+        Source: str | None = None,  # noqa: N803
+        License: str | None = None,  # noqa: N803
+        Relation: str | None = None,  # noqa: N803
         **extras: str,
     ):
         """Sets all mandatory Metadata as well as standard and any other text ones"""
@@ -262,17 +262,15 @@ class Creator(libzim.writer.Creator):
     def add_item_for(
         self,
         path: str,
-        title: Optional[str] = None,
-        fpath: Optional[pathlib.Path] = None,
-        content: Optional[Union[bytes, str]] = None,
-        mimetype: Optional[str] = None,
-        is_front: Optional[bool] = None,
-        should_compress: Optional[bool] = None,
-        delete_fpath: Optional[bool] = False,  # noqa: FBT002
-        duplicate_ok: Optional[bool] = None,
-        callback: Optional[
-            Union[callable, tuple[callable, Any]]  # pyright: ignore
-        ] = None,
+        title: str | None = None,
+        fpath: pathlib.Path | None = None,
+        content: bytes | str | None = None,
+        mimetype: str | None = None,
+        is_front: bool | None = None,
+        should_compress: bool | None = None,
+        delete_fpath: bool | None = False,  # noqa: FBT002
+        duplicate_ok: bool | None = None,
+        callback: Callable | tuple[Callable, Any] | None = None,
     ):
         """Add a File or content at a specified path and get its path
 
@@ -330,8 +328,8 @@ class Creator(libzim.writer.Creator):
     def add_item(
         self,
         item: libzim.writer.Item,
-        duplicate_ok: Optional[bool] = None,
-        callback: Optional[Union[Callable, tuple[Callable, Any]]] = None,
+        duplicate_ok: bool | None = None,
+        callback: Callable | tuple[Callable, Any] | None = None,
     ):
         """Add a libzim.writer.Item
 
@@ -360,9 +358,9 @@ class Creator(libzim.writer.Creator):
         self,
         path: str,
         target_path: str,
-        title: Optional[str] = "",
-        is_front: Optional[bool] = None,
-        duplicate_ok: Optional[bool] = None,
+        title: str | None = "",
+        is_front: bool | None = None,
+        duplicate_ok: bool | None = None,
     ):
         """Add a redirect from path to target_path
 

--- a/src/zimscraperlib/zim/filesystem.py
+++ b/src/zimscraperlib/zim/filesystem.py
@@ -32,7 +32,6 @@ import datetime
 import pathlib
 import re
 from collections.abc import Sequence
-from typing import Optional
 
 from zimscraperlib import logger
 from zimscraperlib.filesystem import get_file_mimetype
@@ -93,8 +92,8 @@ def add_to_zim(
 
 def add_redirects_to_zim(
     zim_file: Creator,
-    redirects: Optional[Sequence[tuple[str, str, Optional[str]]]] = None,
-    redirects_file: Optional[pathlib.Path] = None,
+    redirects: Sequence[tuple[str, str, str | None]] | None = None,
+    redirects_file: pathlib.Path | None = None,
 ):
     """add redirects from list of source/target or redirects file to zim"""
     if redirects is None:

--- a/src/zimscraperlib/zim/items.py
+++ b/src/zimscraperlib/zim/items.py
@@ -3,13 +3,14 @@
 
 
 """ libzim Item helpers """
+from __future__ import annotations
 
 import io
 import pathlib
 import re
 import tempfile
 import urllib.parse
-from typing import Any, Optional, Union
+from typing import Any
 
 import libzim.writer  # pyright: ignore
 
@@ -27,10 +28,10 @@ class Item(libzim.writer.Item):
 
     def __init__(
         self,
-        path: Optional[str] = None,
-        title: Optional[str] = None,
-        mimetype: Optional[str] = None,
-        hints: Optional[dict] = None,
+        path: str | None = None,
+        title: str | None = None,
+        mimetype: str | None = None,
+        hints: dict | None = None,
         **kwargs: Any,
     ):
         super().__init__()
@@ -72,13 +73,13 @@ class StaticItem(Item):
 
     def __init__(
         self,
-        content: Optional[Union[str, bytes]] = None,
-        fileobj: Optional[io.IOBase] = None,
-        filepath: Optional[pathlib.Path] = None,
-        path: Optional[str] = None,
-        title: Optional[str] = None,
-        mimetype: Optional[str] = None,
-        hints: Optional[dict] = None,
+        content: str | bytes | None = None,
+        fileobj: io.IOBase | None = None,
+        filepath: pathlib.Path | None = None,
+        path: str | None = None,
+        title: str | None = None,
+        mimetype: str | None = None,
+        hints: dict | None = None,
         **kwargs: Any,
     ):
         if content is not None:
@@ -148,11 +149,11 @@ class URLItem(StaticItem):
     def __init__(
         self,
         url: str,
-        path: Optional[str] = None,
-        title: Optional[str] = None,
-        mimetype: Optional[str] = None,
-        hints: Optional[dict] = None,
-        use_disk: Optional[bool] = None,
+        path: str | None = None,
+        title: str | None = None,
+        mimetype: str | None = None,
+        hints: dict | None = None,
+        use_disk: bool | None = None,
         **kwargs: Any,
     ):
         if use_disk is not None:

--- a/src/zimscraperlib/zim/metadata.py
+++ b/src/zimscraperlib/zim/metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import re
 from collections.abc import Iterable
-from typing import Any, Union
+from typing import Any
 
 from zimscraperlib.constants import (
     ILLUSTRATIONS_METADATA_RE,
@@ -47,7 +47,7 @@ def validate_title(name: str, value: str):
         raise ValueError(f"{name} is too long.")
 
 
-def validate_date(name: str, value: Union[datetime.datetime, datetime.date, str]):
+def validate_date(name: str, value: datetime.datetime | datetime.date | str):
     """ensures Date metadata can be casted to an ISO 8601 string"""
     if name == "Date":
         if not isinstance(value, (datetime.datetime, datetime.date, str)):
@@ -65,7 +65,7 @@ def validate_date(name: str, value: Union[datetime.datetime, datetime.date, str]
                 raise ValueError(f"Invalid {name} format: {exc}") from None
 
 
-def validate_language(name: str, value: Union[Iterable[str], str]):
+def validate_language(name: str, value: Iterable[str] | str):
     """ensures Language metadata is a single or list of ISO-639-3 codes"""
     if name == "Language":
         if isinstance(value, str):
@@ -96,7 +96,7 @@ def validate_longdescription(name: str, value: str):
         raise ValueError(f"{name} is too long.")
 
 
-def validate_tags(name: str, value: Union[Iterable[str], str]):
+def validate_tags(name: str, value: Iterable[str] | str):
     """ensures Tags metadata is either one or a list of strings"""
     if name == "Tags" and (
         not isinstance(value, Iterable)

--- a/src/zimscraperlib/zim/providers.py
+++ b/src/zimscraperlib/zim/providers.py
@@ -9,9 +9,10 @@
         (and thus Provider instanced twice)
     - to release whatever needs to be once we know data won't be fetched anymore """
 
+from __future__ import annotations
+
 import io
 import pathlib
-from typing import Optional, Union
 
 import libzim.writer  # pyright: ignore
 import requests
@@ -23,15 +24,15 @@ class FileProvider(libzim.writer.FileProvider):
     def __init__(
         self,
         filepath: pathlib.Path,
-        size: Optional[int] = None,  # noqa: ARG002
-        ref: Optional[object] = None,
+        size: int | None = None,  # noqa: ARG002
+        ref: object | None = None,
     ):
         super().__init__(filepath)
         self.ref = ref
 
 
 class StringProvider(libzim.writer.StringProvider):
-    def __init__(self, content: Union[str, bytes], ref: Optional[object] = None):
+    def __init__(self, content: str | bytes, ref: object | None = None):
         super().__init__(content)
         self.ref = ref
 
@@ -45,8 +46,8 @@ class FileLikeProvider(libzim.writer.ContentProvider):
     def __init__(
         self,
         fileobj: io.IOBase,
-        size: Optional[int] = None,
-        ref: Optional[object] = None,
+        size: int | None = None,
+        ref: object | None = None,
     ):
         super().__init__()
         self.ref = ref
@@ -71,9 +72,7 @@ class URLProvider(libzim.writer.ContentProvider):
 
     Useful for non-indexed content for which feed() is called only once"""
 
-    def __init__(
-        self, url: str, size: Optional[int] = None, ref: Optional[object] = None
-    ):
+    def __init__(self, url: str, size: int | None = None, ref: object | None = None):
         super().__init__()
         self.url = url
         self.size = size if size is not None else self.get_size_of(url)
@@ -85,7 +84,7 @@ class URLProvider(libzim.writer.ContentProvider):
         self.resp.raise_for_status()
 
     @staticmethod
-    def get_size_of(url) -> Union[int, None]:
+    def get_size_of(url) -> int | None:
         _, headers = stream_file(url, byte_stream=io.BytesIO(), only_first_block=True)
         try:
             return int(headers["Content-Length"])

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -7,7 +7,7 @@ import concurrent.futures
 import io
 import pathlib
 import re
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 import pytest
 import requests
@@ -234,7 +234,7 @@ def custom_outtmpl() -> str:
 
 
 class WrongOuttmplType(BestWebm):
-    options: ClassVar[dict[str, Optional[Union[str, bool, int]]]] = {"outtmpl": 123}
+    options: ClassVar[dict[str, str | bool | int | None]] = {"outtmpl": 123}
 
 
 def test_get_options_wrong_outtmpl_type():

--- a/tests/inputs/test_inputs.py
+++ b/tests/inputs/test_inputs.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # vim: ai ts=4 sts=4 et sw=4 nu
 
+from __future__ import annotations
+
 import pathlib
-from typing import Optional
 
 import pytest
 
@@ -14,9 +15,7 @@ from zimscraperlib.constants import (
 from zimscraperlib.constants import (
     MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH as MAX_LONG_DESC_LENGTH,
 )
-from zimscraperlib.constants import (
-    NAME as PROJECT_NAME,
-)
+from zimscraperlib.constants import NAME as PROJECT_NAME
 from zimscraperlib.inputs import compute_descriptions, handle_user_provided_file
 
 
@@ -277,7 +276,7 @@ LONG_TEXT = (
 )
 def test_description(
     user_description: str,
-    user_long_description: Optional[str],
+    user_long_description: str | None,
     default_description: str,
     *,
     raises: bool,

--- a/tests/video/test_encoding.py
+++ b/tests/video/test_encoding.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -72,8 +71,8 @@ def test_build_ffmpeg_args(
     src_path: Path,
     tmp_path: Path,
     ffmpeg_args: list[str],
-    threads: Optional[int],
-    expected: Optional[list[str]],
+    threads: int | None,
+    expected: list[str] | None,
 ):
     if expected:
         assert (

--- a/tests/zim/test_metadata.py
+++ b/tests/zim/test_metadata.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
-from typing import Union
 
 import pytest
 
@@ -18,7 +17,7 @@ from zimscraperlib.zim import metadata
         ("Other", "not_an_iso_639_3_code"),
     ],
 )
-def test_validate_language_valid(name: str, value: Union[Iterable[str], str]):
+def test_validate_language_valid(name: str, value: Iterable[str] | str):
     metadata.validate_language(name, value)
 
 
@@ -30,6 +29,6 @@ def test_validate_language_valid(name: str, value: Union[Iterable[str], str]):
         ("Language", "fra, eng"),
     ],
 )
-def test_validate_language_invalid(name: str, value: Union[Iterable[str], str]):
+def test_validate_language_invalid(name: str, value: Iterable[str] | str):
     with pytest.raises(ValueError, match=re.escape("is not ISO-639-3")):
         metadata.validate_language(name, value)


### PR DESCRIPTION
## Rationale
To simplify the expressions for complex Union and Optional combinations using pipe (|) character

## Changes
- Refactor `Optional` and `Union` types from the `typing` module to simpler forms using the pipe character
- This aims to be a supplementary fix for #106 to support PR #140 