### PR TITLE
Add back a runinstalled marker for ogvjs tests

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -41,6 +41,7 @@ jobs:
         if: matrix.python == '3.12'
         uses: codecov/codecov-action@v3
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build_python:

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -35,7 +35,7 @@ jobs:
           pip install -e .[test,scripts]
 
       - name: Run the tests
-        run: inv coverage --args "--runslow -vvv"
+        run: inv coverage --args "--runslow --runinstalled -vvv"
 
       - name: Upload coverage report to codecov
         if: matrix.python == '3.12'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Simplify type annotations by replacing Union and Optional with pipe character ("|") for improved readability and clarity
 
+### Fixed
+- Add back the `--runinstalled` flag for test execution to allow smooth testing on other build chains (#139)
+
 ## [3.3.2] - 2024-03-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ apk add ffmpeg gifsicle libmagic wget libjpeg
 
 # Contribution
 
-This project adheres to openZIM's [Contribution Guidelines](https://github.com/openzim/overview/wiki/Contributing)
+This project adheres to openZIM's [Contribution Guidelines](https://github.com/openzim/overview/wiki/Contributing).
+
+This project has implemented openZIM's [Python bootstrap, conventions and policies](https://github.com/openzim/_python-bootstrap/docs/Policy.md) **v1.0.2**.
 
 ```shell
 pip install hatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-openzim"]
+requires = ["hatchling", "hatch-openzim>=0.2"]
 build-backend = "hatchling.build"
 
 [project]
@@ -25,11 +25,10 @@ dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 
 [tool.hatch.metadata.hooks.openzim-metadata]
 kind = "scraper"
-# not yet supported in hatch-openzim 0.1
-# additional-classifiers = [
-#   "Development Status :: 5 - Production/Stable",
-#   "Intended Audience :: Developers",
-# ]
+additional-classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+]
 
 [project.optional-dependencies]
 scripts = [

--- a/tasks.py
+++ b/tasks.py
@@ -24,6 +24,7 @@ def report_cov(ctx: Context, *, html: bool = False):
     """report coverage"""
     ctx.run("coverage combine", warn=True, pty=use_pty)
     ctx.run("coverage report --show-missing", pty=use_pty)
+    ctx.run("coverage xml", pty=use_pty)
     if html:
         ctx.run("coverage html", pty=use_pty)
 
@@ -92,7 +93,7 @@ def fix_black(ctx: Context, args: str = "."):
 def fix_ruff(ctx: Context, args: str = "."):
     """fix all ruff rules"""
     args = args or "."  # needed for hatch script
-    ctx.run(f"ruff --fix {args}", pty=use_pty)
+    ctx.run(f"ruff check --fix {args}", pty=use_pty)
 
 
 @task(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,16 +10,28 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
+    parser.addoption(
+        "--runinstalled",
+        action="store_true",
+        default=False,
+        help="run tests checking for installed features",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line(
+        "markers", "installed: mark test as testing installed features"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
     skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    skip_installed = pytest.mark.skip(reason="need --runinstalled option to run")
 
     for item in items:
+        if "installed" in item.keywords and not config.getoption("--runinstalled"):
+            item.add_marker(skip_installed)
         if "slow" in item.keywords and not config.getoption("--runslow"):
             item.add_marker(skip_slow)
 

--- a/tests/ogvjs/test_ogvjs.py
+++ b/tests/ogvjs/test_ogvjs.py
@@ -44,6 +44,7 @@ def prepare_ogvjs_folder(tmp_path, videojs_url, ogvjs_url, videojs_ogvjs_url):
     tmp_path.joinpath(member).rename(tmp_path.joinpath("videojs-ogvjs.js"))
 
 
+@pytest.mark.installed
 def test_ogvjs_installed_script_missing_param():
     # run from installed script to check real conditions
     script = subprocess.run(
@@ -63,6 +64,7 @@ def test_ogvjs_from_code_missing_params():
 
 
 @pytest.mark.slow
+@pytest.mark.installed
 def test_ogvjs_installed_script_ok(tmp_path, videojs_url, ogvjs_url, videojs_ogvjs_url):
     # run from installed script to check real conditions
 


### PR DESCRIPTION
Fix #139

Before 3.3, there was a `--runinstalled` switch for tests to disable by default the execution of some tests which were deemed to work only if the package tools were installed.

In 3.3.0, we assumed this switch was not necessary anymore before with new Python bootstrap convention, we are always in installed mode.

This statement was indeed wrong because some persons are building and testing without using our build chain (e.g. they build and test directly from sdist).

This PR adds back the `--runinstalled` switch for tests and corresponding pytest marker to mark tests that are going to work only if package tools are installed.

This PR also implements Python bootstrap 1.0.2 and missing classifiers in Python project