### PR TITLE
Drop disallowed control characters and strip blank characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add utility function to compute ZIM Tags #164, including deduplication #156
+- Metadata does not automatically drops control characters #159
 
 ### Fixed
 


### PR DESCRIPTION
Fix #159
Fix https://github.com/openzim/warc2zim/issues/128

- Automatically drop all control characters in metadata except `\r`, `\n` and `\t`
- Automatically strip blank characters ` `, `\r`, `\n` and `\t` in metadata