### PR TITLE
More changes for mindtouch scraper

### DIFF
--- a/src/zimscraperlib/rewriting/css.py
+++ b/src/zimscraperlib/rewriting/css.py
@@ -51,7 +51,7 @@ class FallbackRegexCssRewriter(RxRewriter):
             [
                 "url(",
                 m_object["quote"],
-                url_rewriter(m_object["url"], base_href),
+                url_rewriter(m_object["url"], base_href).rewriten_url,
                 m_object["quote"],
                 ")",
             ]
@@ -190,7 +190,7 @@ class CssRewriter:
                 new_url = self.url_rewriter(
                     url_node.value,  # pyright: ignore
                     self.base_href,
-                )
+                ).rewriten_url
                 url_node.value = str(new_url)  # pyright: ignore
                 url_node.representation = (  # pyright: ignore
                     f'"{serialize_url(str(new_url))}"'
@@ -206,7 +206,9 @@ class CssRewriter:
         elif isinstance(node, ast.Declaration):
             self._process_list(node.value)  # pyright: ignore
         elif isinstance(node, ast.URLToken):
-            new_url = self.url_rewriter(node.value, self.base_href)  # pyright: ignore
+            new_url = self.url_rewriter(
+                node.value, self.base_href
+            ).rewriten_url  # pyright: ignore
             node.value = new_url
             node.representation = f"url({serialize_url(new_url)})"
 

--- a/src/zimscraperlib/rewriting/html.py
+++ b/src/zimscraperlib/rewriting/html.py
@@ -603,7 +603,9 @@ def rewrite_href_src_attributes(
         notify_js_module(url_rewriter.get_item_path(attr_value, base_href=base_href))
     return (
         attr_name,
-        url_rewriter(attr_value, base_href=base_href, rewrite_all_url=tag != "a"),
+        url_rewriter(
+            attr_value, base_href=base_href, rewrite_all_url=tag != "a"
+        ).rewriten_url,
     )
 
 
@@ -618,10 +620,10 @@ def rewrite_srcset_attribute(
     if attr_name != "srcset" or not attr_value:
         return
     value_list = attr_value.split(",")
-    new_value_list = []
+    new_value_list: list[str] = []
     for value in value_list:
         url, *other = value.strip().split(" ", maxsplit=1)
-        new_url = url_rewriter(url, base_href=base_href)
+        new_url = url_rewriter(url, base_href=base_href).rewriten_url
         new_value = " ".join([new_url, *other])
         new_value_list.append(new_value)
     return (attr_name, ", ".join(new_value_list))
@@ -711,5 +713,6 @@ def rewrite_meta_http_equiv_redirect(
         return
     return (
         attr_name,
-        f"{match['interval']};url={url_rewriter(match['url'], base_href=base_href)}",
+        f"{match['interval']};"
+        f"url={url_rewriter(match['url'], base_href=base_href).rewriten_url}",
     )

--- a/src/zimscraperlib/rewriting/html.py
+++ b/src/zimscraperlib/rewriting/html.py
@@ -132,9 +132,9 @@ class HtmlRewriter(HTMLParser):
     def __init__(
         self,
         url_rewriter: ArticleUrlRewriter,
-        pre_head_insert: str,
+        pre_head_insert: str | None,
         post_head_insert: str | None,
-        notify_js_module: Callable[[ZimPath], None],
+        notify_js_module: Callable[[ZimPath], None] | None,
     ):
         super().__init__(convert_charrefs=False)
         self.url_rewriter = url_rewriter
@@ -430,7 +430,7 @@ class HTMLRewritingRules:
         css_rewriter: CssRewriter,
         url_rewriter: ArticleUrlRewriter,
         base_href: str | None,
-        notify_js_module: Callable[[ZimPath], None],
+        notify_js_module: Callable[[ZimPath], None] | None,
     ) -> AttrNameAndValue:
         """Utility function to process all attribute rewriting rules
 
@@ -587,7 +587,7 @@ def rewrite_href_src_attributes(
     attrs: AttrsList,
     url_rewriter: ArticleUrlRewriter,
     base_href: str | None,
-    notify_js_module: Callable[[ZimPath], None],
+    notify_js_module: Callable[[ZimPath], None] | None,
 ):
     """Rewrite href and src attributes
 
@@ -596,7 +596,10 @@ def rewrite_href_src_attributes(
     """
     if attr_name not in ("href", "src") or not attr_value:
         return
-    if get_html_rewrite_context(tag=tag, attrs=attrs) == "js-module":
+    if (
+        notify_js_module
+        and get_html_rewrite_context(tag=tag, attrs=attrs) == "js-module"
+    ):
         notify_js_module(url_rewriter.get_item_path(attr_value, base_href=base_href))
     return (
         attr_name,

--- a/src/zimscraperlib/rewriting/js.py
+++ b/src/zimscraperlib/rewriting/js.py
@@ -206,7 +206,7 @@ class JsRewriter(RxRewriter):
         self,
         url_rewriter: ArticleUrlRewriter,
         base_href: str | None,
-        notify_js_module: Callable[[ZimPath], None],
+        notify_js_module: Callable[[ZimPath], None] | None,
     ):
         super().__init__(None)
         self.first_buff = self._init_local_declaration(GLOBAL_OVERRIDES)
@@ -298,11 +298,12 @@ class JsRewriter(RxRewriter):
                 m_object: re.Match[str], _opts: dict[str, Any] | None = None
             ) -> str:
                 def sub_funct(match: re.Match[str]) -> str:
-                    self.notify_js_module(
-                        self.url_rewriter.get_item_path(
-                            match.group(2), base_href=self.base_href
+                    if self.notify_js_module:
+                        self.notify_js_module(
+                            self.url_rewriter.get_item_path(
+                                match.group(2), base_href=self.base_href
+                            )
                         )
-                    )
                     return (
                         f"{match.group(1)}{get_rewriten_import_url(match.group(2))}"
                         f"{match.group(3)}"

--- a/src/zimscraperlib/rewriting/js.py
+++ b/src/zimscraperlib/rewriting/js.py
@@ -286,7 +286,7 @@ class JsRewriter(RxRewriter):
             This takes into account that the result must be a relative URL, i.e. it
             cannot be 'vendor.module.js' but must be './vendor.module.js'.
             """
-            url = self.url_rewriter(url, base_href=self.base_href)
+            url = self.url_rewriter(url, base_href=self.base_href).rewriten_url
             if not (
                 url.startswith("/") or url.startswith("./") or url.startswith("../")
             ):

--- a/src/zimscraperlib/rewriting/url_rewriting.py
+++ b/src/zimscraperlib/rewriting/url_rewriting.py
@@ -82,7 +82,7 @@ class HttpUrl:
         return f"HttpUrl({self.value})"
 
     def __repr__(self) -> str:
-        return f"{self.__str__} - {super().__repr__()}"  # pragma: no cover
+        return f"HttpUrl({self.value})"  # pragma: no cover
 
     @property
     def value(self) -> str:
@@ -124,7 +124,7 @@ class ZimPath:
         return f"ZimPath({self.value})"
 
     def __repr__(self) -> str:
-        return f"{self.__str__} - {super().__repr__()}"  # pragma: no cover
+        return f"ZimPath({self.value})"  # pragma: no cover
 
     @property
     def value(self) -> str:

--- a/tests/rewriting/conftest.py
+++ b/tests/rewriting/conftest.py
@@ -7,6 +7,7 @@ from zimscraperlib.rewriting.js import JsRewriter
 from zimscraperlib.rewriting.url_rewriting import (
     ArticleUrlRewriter,
     HttpUrl,
+    RewriteResult,
     ZimPath,
 )
 
@@ -24,8 +25,12 @@ class SimpleUrlRewriter(ArticleUrlRewriter):
         base_href: str | None,  # noqa: ARG002
         *,
         rewrite_all_url: bool = True,  # noqa: ARG002
-    ) -> str:
-        return item_url + self.suffix
+    ) -> RewriteResult:
+        return RewriteResult(
+            absolute_url=item_url + self.suffix,
+            rewriten_url=item_url + self.suffix,
+            zim_path=None,
+        )
 
     def get_item_path(
         self, item_url: str, base_href: str | None  # noqa: ARG002

--- a/tests/rewriting/conftest.py
+++ b/tests/rewriting/conftest.py
@@ -11,16 +11,6 @@ from zimscraperlib.rewriting.url_rewriting import (
 )
 
 
-@pytest.fixture(scope="module")
-def no_js_notify():
-    """Fixture to not care about notification of detection of a JS file"""
-
-    def no_js_notify_handler(_: str):
-        pass
-
-    yield no_js_notify_handler
-
-
 class SimpleUrlRewriter(ArticleUrlRewriter):
     """Basic URL rewriter mocking most calls"""
 

--- a/tests/rewriting/test_html_rewriting.py
+++ b/tests/rewriting/test_html_rewriting.py
@@ -74,17 +74,15 @@ def no_rewrite_content(request: pytest.FixtureRequest):
     yield request.param
 
 
-def test_no_rewrite(
-    no_rewrite_content: ContentForTests, no_js_notify: Callable[[ZimPath], None]
-):
+def test_no_rewrite(no_rewrite_content: ContentForTests):
     assert (
         HtmlRewriter(
             ArticleUrlRewriter(
                 article_url=HttpUrl(f"http://{no_rewrite_content.article_url}"),
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(no_rewrite_content.input_str)
         .content
@@ -116,17 +114,15 @@ def escaped_content(request: pytest.FixtureRequest):
     yield request.param
 
 
-def test_escaped_content(
-    escaped_content: ContentForTests, no_js_notify: Callable[[ZimPath], None]
-):
+def test_escaped_content(escaped_content: ContentForTests):
     transformed = (
         HtmlRewriter(
             ArticleUrlRewriter(
                 article_url=HttpUrl(f"http://{escaped_content.article_url}")
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(escaped_content.input_str)
         .content
@@ -239,17 +235,15 @@ def js_rewrites(request: pytest.FixtureRequest):
     yield request.param
 
 
-def test_js_rewrites(
-    js_rewrites: ContentForTests, no_js_notify: Callable[[ZimPath], None]
-):
+def test_js_rewrites(js_rewrites: ContentForTests):
     transformed = (
         HtmlRewriter(
             ArticleUrlRewriter(
                 article_url=HttpUrl(f"http://{js_rewrites.article_url}")
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(js_rewrites.input_str)
         .content
@@ -334,16 +328,16 @@ def rewrite_url(request: pytest.FixtureRequest):
     yield request.param
 
 
-def test_rewrite(rewrite_url: ContentForTests, no_js_notify: Callable[[ZimPath], None]):
+def test_rewrite(rewrite_url: ContentForTests):
     assert (
         HtmlRewriter(
             ArticleUrlRewriter(
                 article_url=HttpUrl(f"http://{rewrite_url.article_url}"),
                 existing_zim_paths={ZimPath("exemple.com/a/long/path")},
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(rewrite_url.input_str)
         .content
@@ -351,7 +345,7 @@ def test_rewrite(rewrite_url: ContentForTests, no_js_notify: Callable[[ZimPath],
     )
 
 
-def test_extract_title(no_js_notify: Callable[[ZimPath], None]):
+def test_extract_title():
     content = """<html>
       <head>
         <title>Page title</title>
@@ -367,9 +361,9 @@ def test_extract_title(no_js_notify: Callable[[ZimPath], None]):
                 article_url=HttpUrl("http://example.com"),
                 existing_zim_paths={ZimPath("exemple.com/a/long/path")},
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(content)
         .title
@@ -377,15 +371,15 @@ def test_extract_title(no_js_notify: Callable[[ZimPath], None]):
     )
 
 
-def test_rewrite_attributes(no_js_notify: Callable[[ZimPath], None]):
+def test_rewrite_attributes():
     rewriter = HtmlRewriter(
         ArticleUrlRewriter(
             article_url=HttpUrl("http://kiwix.org/"),
             existing_zim_paths={ZimPath("kiwix.org/foo")},
         ),
-        "",
-        "",
-        no_js_notify,
+        None,
+        None,
+        None,
     )
 
     assert (
@@ -407,13 +401,13 @@ def test_rewrite_attributes(no_js_notify: Callable[[ZimPath], None]):
     )
 
 
-def test_rewrite_css(no_js_notify: Callable[[ZimPath], None]):
+def test_rewrite_css():
     output = (
         HtmlRewriter(
             ArticleUrlRewriter(article_url=HttpUrl("http://kiwix.org/")),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(
             "<style>p { /* A comment with a http://link.org/ */ "
@@ -427,7 +421,7 @@ def test_rewrite_css(no_js_notify: Callable[[ZimPath], None]):
     )
 
 
-def test_head_insert(no_js_notify: Callable[[ZimPath], None]):
+def test_head_insert():
     content = """<html>
     <head>
         <title>A test content</title>
@@ -439,18 +433,17 @@ def test_head_insert(no_js_notify: Callable[[ZimPath], None]):
 
     url_rewriter = ArticleUrlRewriter(article_url=HttpUrl("http://kiwix.org/"))
     assert (
-        HtmlRewriter(url_rewriter, "", "", no_js_notify).rewrite(content).content
-        == content
+        HtmlRewriter(url_rewriter, None, None, None).rewrite(content).content == content
     )
 
-    assert HtmlRewriter(url_rewriter, "PRE_HEAD_INSERT", "", no_js_notify).rewrite(
+    assert HtmlRewriter(url_rewriter, "PRE_HEAD_INSERT", None, None).rewrite(
         content
     ).content == content.replace("<head>", "<head>PRE_HEAD_INSERT")
-    assert HtmlRewriter(url_rewriter, "", "POST_HEAD_INSERT", no_js_notify).rewrite(
+    assert HtmlRewriter(url_rewriter, None, "POST_HEAD_INSERT", None).rewrite(
         content
     ).content == content.replace("</head>", "POST_HEAD_INSERT</head>")
     assert HtmlRewriter(
-        url_rewriter, "PRE_HEAD_INSERT", "POST_HEAD_INSERT", no_js_notify
+        url_rewriter, "PRE_HEAD_INSERT", "POST_HEAD_INSERT", None
     ).rewrite(content).content == content.replace(
         "<head>", "<head>PRE_HEAD_INSERT"
     ).replace(
@@ -735,9 +728,7 @@ def rewrite_base_href_content(request):
     yield request.param
 
 
-def test_rewrite_base_href(
-    rewrite_base_href_content: ContentForTests, no_js_notify: Callable[[ZimPath], None]
-):
+def test_rewrite_base_href(rewrite_base_href_content: ContentForTests):
     assert (
         HtmlRewriter(
             ArticleUrlRewriter(
@@ -750,9 +741,9 @@ def test_rewrite_base_href(
                     ZimPath("kiwix.org/favicon.png"),
                 },
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(rewrite_base_href_content.input_str)
         .content
@@ -795,15 +786,13 @@ def test_rewrite_base_href(
         ),
     ],
 )
-def test_simple_rewrite(
-    input_content: str, expected_output: str, no_js_notify: Callable[[ZimPath], None]
-):
+def test_simple_rewrite(input_content: str, expected_output: str):
     assert (
         HtmlRewriter(
             ArticleUrlRewriter(article_url=HttpUrl("http://example.com")),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(input_content)
         .content
@@ -862,9 +851,7 @@ def rewrite_onxxx_content(request: pytest.FixtureRequest):
     yield request.param
 
 
-def test_rewrite_onxxx_event(
-    rewrite_onxxx_content: ContentForTests, no_js_notify: Callable[[ZimPath], None]
-):
+def test_rewrite_onxxx_event(rewrite_onxxx_content: ContentForTests):
     assert (
         HtmlRewriter(
             ArticleUrlRewriter(
@@ -877,9 +864,9 @@ def test_rewrite_onxxx_event(
                     ZimPath("kiwix.org/favicon.png"),
                 },
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(rewrite_onxxx_content.input_str)
         .content
@@ -924,10 +911,7 @@ def rewrite_meta_charset_content(request: pytest.FixtureRequest):
     yield request.param
 
 
-def test_rewrite_meta_charset(
-    rewrite_meta_charset_content: ContentForTests,
-    no_js_notify: Callable[[ZimPath], None],
-):
+def test_rewrite_meta_charset(rewrite_meta_charset_content: ContentForTests):
     assert (
         HtmlRewriter(
             ArticleUrlRewriter(
@@ -935,9 +919,9 @@ def test_rewrite_meta_charset(
                     f"http://{rewrite_meta_charset_content.article_url}"
                 )
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(rewrite_meta_charset_content.input_str)
         .content
@@ -963,7 +947,6 @@ def rewrite_meta_http_equiv_redirect_full_content(request: pytest.FixtureRequest
 
 def test_rewrite_meta_http_equiv_redirect_full(
     rewrite_meta_http_equiv_redirect_full_content: ContentForTests,
-    no_js_notify: Callable[[ZimPath], None],
 ):
     assert (
         HtmlRewriter(
@@ -973,9 +956,9 @@ def test_rewrite_meta_http_equiv_redirect_full(
                 ),
                 existing_zim_paths={ZimPath("kiwix.org/somepage")},
             ),
-            "",
-            "",
-            no_js_notify,
+            None,
+            None,
+            None,
         )
         .rewrite(rewrite_meta_http_equiv_redirect_full_content.input_str)
         .content
@@ -1112,11 +1095,12 @@ def rewrite_tag_name(attr_name: str, attr_value: str | None) -> AttrNameAndValue
 @rules.rewrite_attribute()
 def rewrite_call_notify(
     attr_name: str,
-    notify_js_module: Callable[[ZimPath], None],
+    notify_js_module: Callable[[ZimPath], None] | None,
 ) -> AttrNameAndValue | None:
     if attr_name != "call_notify":
         return
-    notify_js_module(ZimPath("foo"))
+    if notify_js_module:
+        notify_js_module(ZimPath("foo"))
     return
 
 

--- a/tests/rewriting/test_js_rewriting.py
+++ b/tests/rewriting/test_js_rewriting.py
@@ -14,13 +14,12 @@ from .utils import ContentForTests
 
 @pytest.fixture
 def simple_js_rewriter(
-    simple_url_rewriter_gen: Callable[[str], ArticleUrlRewriter],
-    no_js_notify: Callable[[ZimPath], None],
+    simple_url_rewriter_gen: Callable[[str], ArticleUrlRewriter]
 ) -> JsRewriter:
     return JsRewriter(
         url_rewriter=simple_url_rewriter_gen("http://www.example.com"),
         base_href=None,
-        notify_js_module=no_js_notify,
+        notify_js_module=None,
     )
 
 
@@ -307,15 +306,13 @@ def rewrite_import_content(request: pytest.FixtureRequest):
     yield request.param
 
 
-def test_import_rewrite(
-    no_js_notify: Callable[[ZimPath], None], rewrite_import_content: ImportTestContent
-):
+def test_import_rewrite(rewrite_import_content: ImportTestContent):
     url_rewriter = ArticleUrlRewriter(
         article_url=HttpUrl(rewrite_import_content.article_url)
     )
     assert (
         JsRewriter(
-            url_rewriter=url_rewriter, base_href=None, notify_js_module=no_js_notify
+            url_rewriter=url_rewriter, base_href=None, notify_js_module=None
         ).rewrite(rewrite_import_content.input_str, opts={"isModule": True})
         == rewrite_import_content.expected_str
     )


### PR DESCRIPTION
Changes:
- fix __repr__ of ZimPath / HttpUrl which where too long and not working 
- add support for no pre_head_insert in html rewriter and no js_notify callback in all rewriters
- instead of build `items_to_download` in the rewriter, return complete url rewrite information so that 'users' (e.g. mindtouch scraper) can decide what they want to do

Nota: 
- this has been tested with upcoming changes for mindtouch scraper and is supposed to be feature-complete. In last (and biggest) change, the signature of rewriters are not significantly modified so it is not expected to cause significant changes in warc2zim once we will start https://github.com/openzim/warc2zim/issues/411