### PR TITLE
Small changes for mindtouch

### DIFF
--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -177,13 +177,13 @@ def stream_file(
     fpath: pathlib.Path | None = None,
     byte_stream: IO[bytes] | None = None,
     block_size: int | None = 1024,
-    proxies: dict | None = None,
+    proxies: dict[str, str] | None = None,
     max_retries: int | None = 5,
     headers: dict[str, str] | None = None,
     session: requests.Session | None = None,
     *,
     only_first_block: bool | None = False,
-) -> tuple[int, requests.structures.CaseInsensitiveDict]:
+) -> tuple[int, requests.structures.CaseInsensitiveDict[str]]:
     """Stream data from a URL to either a BytesIO object or a file
     Arguments -
         fpath - Path of the file where data is sent

--- a/src/zimscraperlib/logging.py
+++ b/src/zimscraperlib/logging.py
@@ -13,6 +13,9 @@ from typing import TextIO
 from zimscraperlib.constants import NAME
 
 DEFAULT_FORMAT = "[%(name)s::%(asctime)s] %(levelname)s:%(message)s"
+DEFAULT_FORMAT_WITH_THREADS = (
+    "[%(name)s::%(threadName)s::%(asctime)s] %(levelname)s:%(message)s"
+)
 VERBOSE_DEPENDENCIES = ["urllib3", "PIL", "boto3", "botocore", "s3transfer"]
 
 


### PR DESCRIPTION
Very simplified version of #211 since for now decided not to include an executor but rely on joblib (or another parallel processing lib) for now.

Changes:
- fix few type hints to be more precise
- add standard log format for displaying threads info

