### PR TITLE
Handle case where JS module is an inline data

### DIFF
--- a/src/zimscraperlib/rewriting/html.py
+++ b/src/zimscraperlib/rewriting/html.py
@@ -602,7 +602,11 @@ def rewrite_href_src_attributes(
     This is also notifying of any JS script found used as a module, so that this script
     is properly rewritten when encountered later on.
     """
-    if attr_name not in ("href", "src") or not attr_value:
+    if (
+        attr_name not in ("href", "src")
+        or not attr_value
+        or attr_value.startswith("data:")
+    ):
         return
     if (
         notify_js_module

--- a/tests/rewriting/test_html_rewriting.py
+++ b/tests/rewriting/test_html_rewriting.py
@@ -68,6 +68,10 @@ from .utils import ContentForTests
         ContentForTests(input_="<!DOCTYPE html>A simple string with doctype"),
         ContentForTests(input_="A simple string with <!-- cc --> comment"),
         ContentForTests(input_="A simple string with <?xml ?> pi"),
+        ContentForTests(
+            input_='<script type="module" '
+            'src="data:application/javascript;base64,QQQQ"></script>'
+        ),
     ]
 )
 def no_rewrite_content(request: pytest.FixtureRequest):
@@ -75,14 +79,18 @@ def no_rewrite_content(request: pytest.FixtureRequest):
 
 
 def test_no_rewrite(no_rewrite_content: ContentForTests):
+
+    def noop_notify(zim_path: ZimPath):
+        pass
+
     assert (
         HtmlRewriter(
-            ArticleUrlRewriter(
+            url_rewriter=ArticleUrlRewriter(
                 article_url=HttpUrl(f"http://{no_rewrite_content.article_url}"),
             ),
-            None,
-            None,
-            None,
+            pre_head_insert=None,
+            post_head_insert=None,
+            notify_js_module=noop_notify,
         )
         .rewrite(no_rewrite_content.input_str)
         .content


### PR DESCRIPTION
Solution for https://github.com/openzim/warc2zim/issues/421 once warc2zim uses the scraperlib (soon).

Changes:
- do not notify of src rewrite when script src is inline data