### PR TITLE
Significantly enhance the safety of metadata manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed `filesystem.validate_zimfile_creatable` to `filesystem.file_creatable` to reflect general applicability to check file creation beyond ZIM files #200
 - Remove any "ZIM" reference in exceptions while working with files #200
+- Significantly enhance the safety of metadata manipulation (#205)
+  - add types for all metadata, one type per metadata name plus some generic ones for non-standard metadata
+    - all types are responsible to validate metadata value at initialization time
+    - validation checks for adherence to the ZIM specification and conventions are automated
+    - cleanup of unwanted control characters and stripping white characters are **automated in all text metadata**
+    - whenever possible, try to **automatically clean a "reasonably" bad metadata** (e.g. automaticall accept and remove duplicate tags - harmless - but not duplicate language codes - codes are supposed to be ordered, so it is a weird situation) ; this is an alignment of paradigm, because for some metadata the lib was permissive, while for other it was quite restrictive ; this PR tries to align this and **make the lib as permissive as possible**, avoiding to fail a scraper for something which could be automatically fixed
+    - it is now possible to disable ZIM conventions checks with `zim.metadata.check_metadata_conventions`
+  - simplify `zim.creator.Creator.config_metadata` by using these types and been more strict:
+    - add new `StandardMetadata` class for standard metadata, including list of mandatory one
+    - by default, all non-standard metadata must start with `X-` prefix
+      - this not yet an openZIM convention / specification, so it is possible to disable this check with `fail_on_missing_prefix` argument
+  - simplify `add_metadata`, use same metadata types
+  - simplify `zim.creator.Creator.start` with new types, and drop all metadata from memory after being passed to the libzim
+  - drop `zim.creator.convert_and_check_metadata` (not usefull anymore, simply use proper metadata type)
+  - move `MANDATORY_ZIM_METADATA_KEYS` and `DEFAULT_DEV_ZIM_METADATA` from `constants` to `zim.metadata` to avoid circular dependencies
+  - new `inputs.unique_values` utility function to compute the list of uniques values from a given list, but preserving initial list order
+  - in `__init__` of `zim.creator.Creator`, rename `disable_metadata_checks` to `check_metadata_conventions` for clarity and brevity
+    - beware that this manipulate the global `zim.metadata.check_metadata_conventions`, so if you have many creator running in parallel, they can't have different settings, last one initialized will "win"
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "regex>=2020.7.14",
   "pymupdf>=1.24.0,<2.0",
   "CairoSVG>=2.2.0,<3.0",
+  "beartype==0.19.0",
   # youtube-dl should be updated as frequently as possible
   "yt-dlp"
 ]
@@ -252,6 +253,8 @@ ban-relative-imports = "all"
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 # _libkiwix mimics libkiwix C++ code, names obey C++ conventions
 "src/zimscraperlib/zim/_libkiwix.py" = ["N802", "N803", "N806"]
+# beartype must be first
+"src/zimscraperlib/zim/__init__.py" = ["E402"]
 
 [tool.pytest.ini_options]
 minversion = "7.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,19 +53,19 @@ scripts = [
 ]
 lint = [
   "black==24.10.0",
-  "ruff==0.7.0",
+  "ruff==0.8.2",
 ]
 check = [
-  "pyright==1.1.385",
-  "pytest==8.3.3",
+  "pyright==1.1.390",
+  "pytest==8.3.4",
 ]
 test = [
-  "pytest==8.3.3",
+  "pytest==8.3.4",
   "pytest-mock==3.14.0",
-  "coverage==7.5.3",
+  "coverage==7.6.9",
 ]
 dev = [
-  "ipython==8.25.0",
+  "ipython==8.30.0",
   "pre-commit==4.0.1",
   "zimscraperlib[scripts]",
   "zimscraperlib[lint]",

--- a/src/zimscraperlib/constants.py
+++ b/src/zimscraperlib/constants.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # vim: ai ts=4 sts=4 et sw=4 nu
 
-import base64
 import pathlib
 import re
 
@@ -21,34 +20,6 @@ ALPHA_NOT_SUPPORTED = ["JPEG", "BMP", "EPS", "PCX"]
 
 # list of mimetypes we consider articles using it should default to FRONT_ARTICLE
 FRONT_ARTICLE_MIMETYPES = ["text/html"]
-
-# list of mandatory meta tags of the zim file.
-MANDATORY_ZIM_METADATA_KEYS = [
-    "Name",
-    "Title",
-    "Creator",
-    "Publisher",
-    "Date",
-    "Description",
-    "Language",
-    "Illustration_48x48@1",
-]
-
-DEFAULT_DEV_ZIM_METADATA = {
-    "Name": "Test Name",
-    "Title": "Test Title",
-    "Creator": "Test Creator",
-    "Publisher": "Test Publisher",
-    "Date": "2023-01-01",
-    "Description": "Test Description",
-    "Language": "fra",
-    # blank 48x48 transparent PNG
-    "Illustration_48x48_at_1": base64.b64decode(
-        "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwAQMAAABtzGvEAAAAGXRFWHRTb2Z0d2FyZQBB"
-        "ZG9iZSBJbWFnZVJlYWR5ccllPAAAAANQTFRFR3BMgvrS0gAAAAF0Uk5TAEDm2GYAAAAN"
-        "SURBVBjTY2AYBdQEAAFQAAGn4toWAAAAAElFTkSuQmCC"
-    ),
-}
 
 RECOMMENDED_MAX_TITLE_LENGTH = 30
 MAXIMUM_DESCRIPTION_METADATA_LENGTH = 80

--- a/src/zimscraperlib/filesystem.py
+++ b/src/zimscraperlib/filesystem.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import os
 import pathlib
-from collections.abc import Callable
-from typing import Any
 
 import magic
 
@@ -44,15 +42,7 @@ def get_content_mimetype(content: bytes | str) -> str:
     return MIME_OVERRIDES.get(detected_mime, detected_mime)
 
 
-def delete_callback(
-    fpath: str | pathlib.Path,
-    callback: Callable | None = None,
-    *callback_args: Any,
-):
-    """helper deleting passed filepath, optionnaly calling an additional callback"""
+def delete_callback(fpath: str | pathlib.Path):
+    """helper deleting passed filepath"""
 
     os.unlink(fpath)
-
-    # call the callback if requested
-    if callback and callable(callback):
-        callback.__call__(*callback_args)

--- a/src/zimscraperlib/image/conversion.py
+++ b/src/zimscraperlib/image/conversion.py
@@ -37,7 +37,7 @@ def convert_image(
     if not fmt:
         raise ValueError("Impossible to guess destination image format")
     with pilopen(src) as image:
-        if image.mode == "RGBA" and fmt in ALPHA_NOT_SUPPORTED or colorspace:
+        if (image.mode == "RGBA" and fmt in ALPHA_NOT_SUPPORTED) or colorspace:
             image = image.convert(colorspace or "RGB")  # noqa: PLW2901
         save_image(image, dst, fmt, **params)
 

--- a/src/zimscraperlib/inputs.py
+++ b/src/zimscraperlib/inputs.py
@@ -136,3 +136,8 @@ def compute_tags(
     return {
         tag.strip() for tag in list(default_tags) + (user_tags or "").split(";") if tag
     }
+
+
+def unique_values(items: list) -> list:
+    """Return unique values in input list while preserving list order"""
+    return list(dict.fromkeys(items))

--- a/src/zimscraperlib/typing.py
+++ b/src/zimscraperlib/typing.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, NamedTuple
+
+
+class Callback(NamedTuple):
+    func: Callable
+    args: tuple[Any, ...] | None = None
+    kwargs: dict[str, Any] | None = None
+
+    @property
+    def callable(self) -> bool:
+        return callable(self.func)
+
+    def get_args(self) -> tuple[Any, ...]:
+        return self.args or ()
+
+    def get_kwargs(self) -> dict[str, Any]:
+        return self.kwargs or {}
+
+    def call_with(self, *args, **kwargs):
+        self.func.__call__(*args, **kwargs)
+
+    def call(self):
+        self.call_with(*self.get_args(), **self.get_kwargs())

--- a/src/zimscraperlib/zim/__init__.py
+++ b/src/zimscraperlib/zim/__init__.py
@@ -9,7 +9,10 @@
     zim.items: item to add to creator
     zim.archive: read ZIM files, accessing or searching its content"""
 
+from beartype.claw import beartype_this_package
 from libzim.writer import Blob  # pyright: ignore
+
+beartype_this_package()
 
 from zimscraperlib.zim.archive import Archive
 from zimscraperlib.zim.creator import Creator

--- a/src/zimscraperlib/zim/__init__.py
+++ b/src/zimscraperlib/zim/__init__.py
@@ -27,14 +27,14 @@ from zimscraperlib.zim.providers import (
 
 __all__ = [
     "Archive",
+    "Blob",
     "Creator",
-    "make_zim_file",
+    "FileLikeProvider",
+    "FileProvider",
     "Item",
     "StaticItem",
-    "URLItem",
-    "FileProvider",
     "StringProvider",
-    "FileLikeProvider",
+    "URLItem",
     "URLProvider",
-    "Blob",
+    "make_zim_file",
 ]

--- a/src/zimscraperlib/zim/_libkiwix.py
+++ b/src/zimscraperlib/zim/_libkiwix.py
@@ -15,12 +15,15 @@ https://github.com/kiwix/libkiwix/blob/master/src/tools/otherTools.cpp
 from __future__ import annotations
 
 import io
-from collections import namedtuple
+from typing import NamedTuple
 
-MimetypeAndCounter = namedtuple("MimetypeAndCounter", ["mimetype", "value"])
-CounterMap = dict[
-    type(MimetypeAndCounter.mimetype), type(MimetypeAndCounter.value)  # pyright: ignore
-]
+
+class MimetypeAndCounter(NamedTuple):
+    mimetype: str
+    value: int
+
+
+type CounterMap = dict[str, int]
 
 
 def getline(src: io.StringIO, delim: str | None = None) -> tuple[bool, str]:

--- a/src/zimscraperlib/zim/archive.py
+++ b/src/zimscraperlib/zim/archive.py
@@ -17,7 +17,7 @@ import libzim.reader  # pyright: ignore
 import libzim.search  # Query, Searcher  # pyright: ignore
 import libzim.suggestion  # SuggestionSearcher  # pyright: ignore
 
-from zimscraperlib.zim._libkiwix import convertTags, parseMimetypeCounter
+from zimscraperlib.zim._libkiwix import CounterMap, convertTags, parseMimetypeCounter
 
 
 class Archive(libzim.reader.Archive):
@@ -101,7 +101,7 @@ class Archive(libzim.reader.Archive):
         return search.getEstimatedMatches()
 
     @property
-    def counters(self) -> dict[str, int]:
+    def counters(self) -> CounterMap:
         try:
             return parseMimetypeCounter(self.get_text_metadata("Counter"))
         except RuntimeError:  # pragma: no cover (no ZIM avail to test itl)

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -191,14 +191,7 @@ class Creator(libzim.writer.Creator):
                     )
                 continue
 
-            # rest is either printable or unexpected
-            try:
-                logger.debug(f"Metadata: {name} = {metadata.value!s}")
-            except Exception:
-                logger.debug(
-                    f"Metadata: {name} is unexpected data type: "
-                    f"{type(metadata.value).__qualname__}"
-                )
+            logger.debug(f"Metadata: {name} = {metadata.value!s}")
 
     def _get_first_language_metadata_value(self) -> str | None:
         """Private methods to get most popular lang code from Language metadata"""

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -43,7 +43,7 @@ from zimscraperlib.zim.items import StaticItem
 from zimscraperlib.zim.metadata import (
     DEFAULT_DEV_ZIM_METADATA,
     MANDATORY_ZIM_METADATA_KEYS,
-    IllustrationMetadata,
+    IllustrationBasedMetadata,
     LanguageMetadata,
     Metadata,
     StandardMetadataList,
@@ -229,7 +229,7 @@ class Creator(libzim.writer.Creator):
         super().__enter__()
 
         for metadata in self._metadata.values():
-            if isinstance(metadata, IllustrationMetadata):
+            if isinstance(metadata, IllustrationBasedMetadata):
                 self.add_illustration(metadata.illustration_size, metadata.libzim_value)
             else:
                 self.add_metadata(metadata)

--- a/src/zimscraperlib/zim/filesystem.py
+++ b/src/zimscraperlib/zim/filesystem.py
@@ -166,11 +166,13 @@ def make_zim_file(
     with open(illustration_path, "rb") as fh:
         illustration_data = fh.read()
 
+    # disable recommendations if requested
+    metadata.APPLY_RECOMMENDATIONS = not disable_metadata_checks
+
     zim_file = Creator(
         filename=fpath,
         main_path=main_page,
         ignore_duplicates=ignore_duplicates,
-        check_metadata_conventions=disable_metadata_checks,
     ).config_metadata(
         metadata.StandardMetadataList(
             # mandatory
@@ -181,8 +183,8 @@ def make_zim_file(
             Language=metadata.LanguageMetadata(language),
             Creator=metadata.CreatorMetadata(creator),
             Publisher=metadata.PublisherMetadata(publisher),
-            Illustration_48x48_at_1=metadata.IllustrationMetadata(
-                "Illustration_48x48@1", illustration_data
+            Illustration_48x48_at_1=metadata.DefaultIllustrationMetadata(
+                illustration_data
             ),
             # optional
             Tags=metadata.TagsMetadata(list(tags)) if tags else None,

--- a/src/zimscraperlib/zim/filesystem.py
+++ b/src/zimscraperlib/zim/filesystem.py
@@ -38,6 +38,7 @@ from zimscraperlib import logger
 from zimscraperlib.filesystem import get_file_mimetype
 from zimscraperlib.html import find_title_in_file
 from zimscraperlib.types import get_mime_for_name
+from zimscraperlib.zim import metadata
 from zimscraperlib.zim.creator import Creator
 from zimscraperlib.zim.items import StaticItem
 
@@ -169,29 +170,31 @@ def make_zim_file(
         filename=fpath,
         main_path=main_page,
         ignore_duplicates=ignore_duplicates,
-        disable_metadata_checks=disable_metadata_checks,
+        check_metadata_conventions=disable_metadata_checks,
     ).config_metadata(
-        **{
-            k: v
-            for k, v in {
-                # (somewhat) mandatory
-                "Name": name,
-                "Title": title,
-                "Description": description,
-                "Date": date or datetime.date.today(),  # noqa: DTZ011
-                "Language": language,
-                "Creator": creator,
-                "Publisher": publisher,
-                # optional
-                "Tags": ";".join(tags) if tags else None,
-                "Source": source,
-                "Flavour": flavour,
-                "Scraper": scraper,
-                "LongDescription": long_description,
-                "Illustration_48x48_at_1": illustration_data,
-            }.items()
-            if v is not None
-        }
+        metadata.StandardMetadataList(
+            # mandatory
+            Name=metadata.NameMetadata(name),
+            Title=metadata.TitleMetadata(title),
+            Description=metadata.DescriptionMetadata(description),
+            Date=metadata.DateMetadata(date or datetime.date.today()),  # noqa: DTZ011
+            Language=metadata.LanguageMetadata(language),
+            Creator=metadata.CreatorMetadata(creator),
+            Publisher=metadata.PublisherMetadata(publisher),
+            Illustration_48x48_at_1=metadata.IllustrationMetadata(
+                "Illustration_48x48@1", illustration_data
+            ),
+            # optional
+            Tags=metadata.TagsMetadata(list(tags)) if tags else None,
+            Source=metadata.SourceMetadata(source) if source else None,
+            Flavour=metadata.FlavourMetadata(flavour) if flavour else None,
+            Scraper=metadata.ScraperMetadata(scraper) if scraper else None,
+            LongDescription=(
+                metadata.LongDescriptionMetadata(long_description)
+                if long_description
+                else None
+            ),
+        )
     )
 
     zim_file.start()

--- a/src/zimscraperlib/zim/metadata.py
+++ b/src/zimscraperlib/zim/metadata.py
@@ -1,21 +1,34 @@
 from __future__ import annotations
 
+import base64
 import datetime
+import io
 import re
-from collections.abc import Iterable
-from typing import Any
+from dataclasses import dataclass
 
 import regex
 
 from zimscraperlib.constants import (
     ILLUSTRATIONS_METADATA_RE,
-    MANDATORY_ZIM_METADATA_KEYS,
     MAXIMUM_DESCRIPTION_METADATA_LENGTH,
     MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH,
     RECOMMENDED_MAX_TITLE_LENGTH,
 )
 from zimscraperlib.i18n import is_valid_iso_639_3
 from zimscraperlib.image.probing import is_valid_image
+from zimscraperlib.inputs import unique_values
+
+# All control characters are disallowed in str metadata except \n, \r and \t
+UNWANTED_CONTROL_CHARACTERS_REGEX = regex.compile(r"(?![\n\t\r])\p{C}")
+
+# flag to enable / disable check conventions (e.g. title shorter than 30 chars,
+# description shorter than 80 chars, ...)
+check_metadata_conventions: bool = True
+
+
+def clean_str(value: str) -> str:
+    """Clean a string value for unwanted control characters and strip white chars"""
+    return UNWANTED_CONTROL_CHARACTERS_REGEX.sub("", value).strip(" \r\n\t")
 
 
 def nb_grapheme_for(value: str) -> int:
@@ -23,123 +36,436 @@ def nb_grapheme_for(value: str) -> int:
     return len(regex.findall(r"\X", value))
 
 
-def validate_required_values(name: str, value: Any):
-    """ensures required ones have a value (spec doesnt requires it but makes sense)"""
-    if name in MANDATORY_ZIM_METADATA_KEYS and not value:
-        raise ValueError(f"Missing value for {name}")
+class Metadata:
+    """A very basic metadata, with a name and a bytes or io.BytesIO value
+
+    Compliance with ZIM specification is done at initialisation, value passed at
+    initialization is kept in memory in `value` attribute, target name is stored in
+    `name` value and conversion to libzim value is available with `libzim_value`
+    property.
+    """
+
+    def __init__(self, name: str, value: bytes | io.BytesIO) -> None:
+        if not isinstance(value, bytes | io.BytesIO):
+            raise ValueError(
+                f"Unexpected type passed to {self.__class__.__qualname__}: "
+                f"{value.__class__.__qualname__}"
+            )
+        if name == "Counter":
+            raise ValueError("Counter cannot be set. libzim sets it.")
+        self.name = name
+        self.value = value
+        libzim_value = self.libzim_value  # to check for errors
+        if libzim_value is None or len(libzim_value) == 0:
+            raise ValueError("Cannot set empty metadata")
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        if isinstance(self.value, io.BytesIO):
+            return self.value.getvalue()
+        return self.value
 
 
-def validate_standard_str_types(
-    name: str,
-    value: str | bytes,
-):
-    """ensures standard string metadata are indeed str"""
-    if name in (
-        "Name",
-        "Title",
-        "Creator",
-        "Publisher",
-        "Description",
-        "LongDescription",
-        "License",
-        "Relation",
-        "Relation",
-        "Flavour",
-        "Source",
-        "Scraper",
-    ) and not isinstance(value, str):
-        raise ValueError(f"Invalid type for {name}: {type(value)}")
+class _TextMetadata(Metadata):
+    """A basic metadata whose value is expected to be some text"""
 
-
-def validate_title(name: str, value: str):
-    """ensures Title metadata is within recommended length"""
-    if name == "Title" and nb_grapheme_for(value) > RECOMMENDED_MAX_TITLE_LENGTH:
-        raise ValueError(f"{name} is too long.")
-
-
-def validate_date(name: str, value: datetime.datetime | datetime.date | str):
-    """ensures Date metadata can be casted to an ISO 8601 string"""
-    if name == "Date":
-        if not isinstance(value, datetime.datetime | datetime.date | str):
-            raise ValueError(f"Invalid type for {name}: {type(value)}")
-        elif isinstance(value, str):
-            match = re.match(r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})", value)
-            if not match:
-                raise ValueError(f"Invalid {name} format, not matching regex")
-            try:
-                datetime.date(**{k: int(v) for k, v in match.groupdict().items()})
-            except Exception as exc:
-                raise ValueError(f"Invalid {name} format: {exc}") from None
-
-
-def validate_language(name: str, value: Iterable[str] | str):
-    """ensures Language metadata is a single or list of ISO-639-3 codes"""
-    if name == "Language":
-        if isinstance(value, str):
-            value = value.split(",")
-        for code in value:
-            if not is_valid_iso_639_3(code):
-                raise ValueError(f"{code} is not ISO-639-3.")
-
-
-def validate_counter(name: str, _: str):
-    """ensures Counter metadata is not manually set"""
-    if name == "Counter":
-        raise ValueError(f"{name} cannot be set. libzim sets it.")
-
-
-def validate_description(name: str, value: str):
-    """ensures Description metadata is with required length"""
-    if (
-        name == "Description"
-        and nb_grapheme_for(value) > MAXIMUM_DESCRIPTION_METADATA_LENGTH
-    ):
-        raise ValueError(f"{name} is too long.")
-
-
-def validate_longdescription(name: str, value: str):
-    """ensures LongDescription metadata is with required length"""
-    if (
-        name == "LongDescription"
-        and nb_grapheme_for(value) > MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH
-    ):
-        raise ValueError(f"{name} is too long.")
-
-
-def validate_tags(name: str, value: Iterable[str] | str):
-    """ensures Tags metadata is either one or a list of strings"""
-    if name == "Tags" and (
-        not isinstance(value, Iterable)
-        or not all(isinstance(tag, str) for tag in value)
-    ):
-        raise ValueError(f"Invalid type(s) for {name}")
-    if (
-        name == "Tags"
-        and not isinstance(value, str)
-        and isinstance(value, Iterable)
-        and len(set(value)) != len(list(value))
-    ):
-        raise ValueError(f"Duplicate tags are not valid: {value}")
-    if name == "Tags" and isinstance(value, str):
-        values = value.split(";")
-        if len(set(values)) != len(list(values)):
-            raise ValueError(f"Duplicate tags are not valid: {value}")
-
-
-def validate_illustrations(name: str, value: bytes):
-    """ensures illustrations are PNG images or the advertised size"""
-    if name.startswith("Illustration_"):
-        match = ILLUSTRATIONS_METADATA_RE.match(name)
-        if match and not is_valid_image(
-            image=value,
-            imformat="PNG",
-            size=(
-                int(match.groupdict()["width"]),
-                int(match.groupdict()["height"]),
+    def __init__(self, name: str, value: bytes | io.BytesIO | str) -> None:
+        if not isinstance(value, bytes | io.BytesIO | str):
+            raise ValueError(
+                f"Unexpected type passed to {self.__class__.__qualname__}: "
+                f"{value.__class__.__qualname__}"
+            )
+        super().__init__(
+            name=name,
+            value=(
+                value.encode()
+                if isinstance(value, str)
+                else value.getvalue() if isinstance(value, io.BytesIO) else value
             ),
+        )
+        self.value = value
+        _ = self.libzim_value  # to check for errors
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        # decode and reencode byte types to validate it's proper UTF-8 text
+        if isinstance(self.value, io.BytesIO):
+            str_value = self.value.getvalue().decode()
+        elif isinstance(self.value, bytes):
+            str_value = self.value.decode()
+        else:
+            str_value = self.value
+        return clean_str(str_value).encode()
+
+
+def _check_for_allowed_custom_metadata_name(name: str, class_name: str):
+    """Check that metadata name is not among the standard ones for which a type exist"""
+    if name in DEFAULT_DEV_ZIM_METADATA.__dict__.keys():
+        # this list contains the 'bad' illustration keys, but we don't care, they should
+        # still not be used
+        raise ValueError(
+            f"It is not allowed to use {class_name} for standard {name} "
+            f"metadata. Please use {name}Metadata type for proper checks"
+        )
+    if name.startswith("Illustration_"):
+        raise ValueError(
+            f"It is not allowed to use {class_name} for standard Illustration"
+            "metadata. Please use IllustrationMetadata type for proper checks"
+        )
+
+
+class CustomTextMetadata(_TextMetadata):
+    """A text metadata for which we do little checks"""
+
+    def __init__(self, name: str, value: bytes | io.BytesIO | str) -> None:
+        _check_for_allowed_custom_metadata_name(name, self.__class__.__qualname__)
+        super().__init__(name=name, value=value)
+
+
+class CustomMetadata(Metadata):
+    """A bytes metadata for which we do little checks"""
+
+    def __init__(self, name: str, value: bytes | io.BytesIO) -> None:
+        _check_for_allowed_custom_metadata_name(name, self.__class__.__qualname__)
+        super().__init__(name=name, value=value)
+
+
+class _MandatoryTextMetadata(_TextMetadata):
+    """A mandatory (value must be set) text metadata"""
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        value = super().libzim_value
+        if len(value) == 0:
+            raise ValueError("Missing value for mandatory metadata")
+        return value
+
+
+class _MandatoryMetadata(Metadata):
+    """A mandatory (value must be set) bytes metadata"""
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        value = super().libzim_value
+        if len(value) == 0:
+            raise ValueError("Missing value for mandatory metadata")
+        return value
+
+
+class TitleMetadata(_MandatoryTextMetadata):
+    """The Title metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__(name="Title", value=value)
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        value = super().libzim_value
+        if check_metadata_conventions:
+            if nb_grapheme_for(value.decode()) > RECOMMENDED_MAX_TITLE_LENGTH:
+                raise ValueError("Title is too long.")
+        return value
+
+
+class DescriptionMetadata(_MandatoryTextMetadata):
+    """The Description metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__(name="Description", value=value)
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        value = super().libzim_value
+        if check_metadata_conventions:
+            if nb_grapheme_for(value.decode()) > MAXIMUM_DESCRIPTION_METADATA_LENGTH:
+                raise ValueError("Description is too long.")
+        return value
+
+
+class LongDescriptionMetadata(_MandatoryTextMetadata):
+    """The LongDescription metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__(name="LongDescription", value=value)
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        value = super().libzim_value
+        if check_metadata_conventions:
+            if (
+                nb_grapheme_for(value.decode())
+                > MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH
+            ):
+                raise ValueError("LongDescription is too long.")
+        return value
+
+
+class DateMetadata(_TextMetadata):
+    """The Date metadata"""
+
+    def __init__(self, value: bytes | str | datetime.date | datetime.datetime) -> None:
+        if not isinstance(value, bytes | str | datetime.date | datetime.datetime):
+            raise ValueError(
+                f"Unexpected type passed to {self.__class__.__qualname__}: "
+                f"{value.__class__.__qualname__}"
+            )
+        super().__init__(
+            name="Date",
+            value=(
+                value
+                if isinstance(value, bytes)
+                else (
+                    value.encode()
+                    if isinstance(value, str)
+                    else value.strftime("%Y-%m-%d").encode()
+                )
+            ),
+        )
+        self.value = value
+        _ = self.libzim_value  # to check for errors
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        if isinstance(self.value, datetime.date | datetime.datetime):
+            return self.value.strftime("%Y-%m-%d").encode()
+        match = re.match(
+            r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})",
+            self.value.decode() if isinstance(self.value, bytes) else self.value,
+        )
+        if not match:
+            raise ValueError("Invalid date format, not matching regex yyyy-mm-dd")
+        try:
+            datetime.date(**{k: int(v) for k, v in match.groupdict().items()})
+        except Exception as exc:
+            raise ValueError(f"Invalid date format: {exc}") from None
+        return self.value if isinstance(self.value, bytes) else self.value.encode()
+
+
+class IllustrationMetadata(_MandatoryMetadata):
+    """Any Illustration_**x**@* metadata"""
+
+    def __init__(self, name: str, value: bytes | io.BytesIO) -> None:
+        super().__init__(name=name, value=value)
+        _ = self.libzim_value  # to check for errors
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        match = ILLUSTRATIONS_METADATA_RE.match(self.name)
+        if not match:
+            raise ValueError("Illustration metadata has improper name")
+        self.size = int(match.groupdict()["height"])
+        if int(match.groupdict()["width"]) != self.size:
+            raise ValueError("Illustration is not squared")
+        if not is_valid_image(
+            image=self.value,
+            imformat="PNG",
+            size=(self.size, self.size),
         ):
             raise ValueError(
-                f"{name} is not a "
-                f"{match.groupdict()['width']}x{match.groupdict()['height']} "
-                "PNG Image"
+                f"{self.name} is not a valid {self.size}x{self.size} PNG Image"
             )
+        if isinstance(self.value, io.BytesIO):
+            return self.value.getvalue()
+        else:
+            return self.value
+
+
+class LanguageMetadata(_MandatoryTextMetadata):
+    """The Language metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str | list[str] | set[str]) -> None:
+        if not isinstance(value, bytes | io.BytesIO | str | list | set):
+            raise ValueError(
+                f"Unexpected type passed to {self.__class__.__qualname__}: "
+                f"{value.__class__.__qualname__}"
+            )
+        if isinstance(value, list | set) and not all(
+            isinstance(item, str) for item in value
+        ):
+            bad_types = {item.__class__.__qualname__ for item in value} - {"str"}
+            raise ValueError(
+                f"Invalid type(s) found in Iterable: {",".join(bad_types)}"
+            )
+        super().__init__(
+            name="Language",
+            value=",".join(value) if isinstance(value, list | set) else value,
+        )
+        self.value = value
+        _ = self.libzim_value  # to check for errors
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        if isinstance(self.value, bytes | io.BytesIO | str):
+            codes = [
+                clean_str(code) for code in super().libzim_value.decode().split(",")
+            ]
+        else:
+            codes = [clean_str(code) for code in self.value]
+        codes = [code for code in codes if code]  # remove empty values
+        if len(codes) == 0:
+            raise ValueError("Missing value for mandatory Language metadata")
+        if len(set(codes)) != len(codes):
+            raise ValueError("Duplicate codes not allowed in Language metadata")
+        for code in codes:
+            if not is_valid_iso_639_3(code):
+                raise ValueError(f"{code} is not ISO-639-3.")
+        return ",".join(codes).encode()
+
+
+class TagsMetadata(_TextMetadata):
+    """The Tags metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str | list[str] | set[str]) -> None:
+        if not isinstance(value, bytes | io.BytesIO | str | list | set):
+            raise ValueError(
+                f"Unexpected type passed to {self.__class__.__qualname__}: "
+                f"{value.__class__.__qualname__}"
+            )
+        if isinstance(value, list | set) and not all(
+            isinstance(item, str) for item in value
+        ):
+            bad_types = {item.__class__.__qualname__ for item in value} - {"str"}
+            raise ValueError(
+                f"Invalid type(s) found in Iterable: {",".join(bad_types)}"
+            )
+        super().__init__(
+            name="Tags",
+            value=";".join(value) if isinstance(value, list | set) else value,
+        )
+        self.value = value
+        _ = self.libzim_value  # to check for errors
+
+    @property
+    def libzim_value(self) -> bytes:
+        """The value to pass to the libzim for creating the metadata"""
+        if isinstance(self.value, bytes | io.BytesIO | str):
+            tags = unique_values(
+                [clean_str(tag) for tag in super().libzim_value.decode().split(";")]
+            )
+        else:
+            tags = unique_values([clean_str(tag) for tag in self.value])
+        tags = [tag for tag in tags if tag]  # remove empty values
+        return ";".join(tags).encode()
+
+
+class NameMetadata(_MandatoryTextMetadata):
+    """The Name metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("Name", value)
+
+
+class CreatorMetadata(_MandatoryTextMetadata):
+    """The Creator metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("Creator", value)
+
+
+class PublisherMetadata(_MandatoryTextMetadata):
+    """The Publisher metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("Publisher", value)
+
+
+class ScraperMetadata(_TextMetadata):
+    """The Scraper metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("Scraper", value)
+
+
+class FlavourMetadata(_TextMetadata):
+    """The Flavour metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("Flavour", value)
+
+
+class SourceMetadata(_TextMetadata):
+    """The Source metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("Source", value)
+
+
+class LicenseMetadata(_TextMetadata):
+    """The License metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("License", value)
+
+
+class RelationMetadata(_TextMetadata):
+    """The Relation metadata"""
+
+    def __init__(self, value: bytes | io.BytesIO | str) -> None:
+        super().__init__("Relation", value)
+
+
+@dataclass
+class StandardMetadataList:
+    """A class holding all openZIM standard metadata
+
+    Useful to ensure that all mandatory metadata are set, no typo occurs in metadata
+    name and the specification is respected (forbidden duplicate values, ...).
+    """
+
+    Name: NameMetadata
+    Language: LanguageMetadata
+    Title: TitleMetadata
+    Creator: CreatorMetadata
+    Publisher: PublisherMetadata
+    Date: DateMetadata
+    Illustration_48x48_at_1: IllustrationMetadata
+    Description: DescriptionMetadata
+    LongDescription: LongDescriptionMetadata | None = None
+    Tags: TagsMetadata | None = None
+    Scraper: ScraperMetadata | None = None
+    Flavour: FlavourMetadata | None = None
+    Source: SourceMetadata | None = None
+    License: LicenseMetadata | None = None
+    Relation: RelationMetadata | None = None
+
+    def values(self) -> list[Metadata]:
+        return [v for v in self.__dict__.values() if v]
+
+
+# A sample standard metadata list, to be used for dev purposes when one does not care
+# at all about metadata values ; this ensures all metadata are compliant with the spec
+DEFAULT_DEV_ZIM_METADATA = StandardMetadataList(
+    Name=NameMetadata("Test Name"),
+    Title=TitleMetadata("Test Title"),
+    Creator=CreatorMetadata("Test Creator"),
+    Publisher=PublisherMetadata("Test Publisher"),
+    Date=DateMetadata("2023-01-01"),
+    Description=DescriptionMetadata("Test Description"),
+    Language=LanguageMetadata("fra"),
+    # blank 48x48 transparent PNG
+    Illustration_48x48_at_1=IllustrationMetadata(
+        "Illustration_48x48@1",
+        base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwAQMAAABtzGvEAAAAGXRFWHRTb2Z0d2FyZQBB"
+            "ZG9iZSBJbWFnZVJlYWR5ccllPAAAAANQTFRFR3BMgvrS0gAAAAF0Uk5TAEDm2GYAAAAN"
+            "SURBVBjTY2AYBdQEAAFQAAGn4toWAAAAAElFTkSuQmCC"
+        ),
+    ),
+)
+
+# list of mandatory metadata of the zim file, automatically computed
+MANDATORY_ZIM_METADATA_KEYS = [
+    metadata.name
+    for metadata in DEFAULT_DEV_ZIM_METADATA.__dict__.values()
+    if isinstance(metadata, _MandatoryTextMetadata | _MandatoryMetadata)
+]

--- a/src/zimscraperlib/zim/metadata.py
+++ b/src/zimscraperlib/zim/metadata.py
@@ -483,14 +483,20 @@ class CustomTextMetadata(TextBasedMetadata):
 
 
 @x_prefixed
-class XCustomMetadata(CustomMetadata): ...
+class XCustomMetadata(CustomMetadata):
+    # reimpl just to please coverage
+    def __init__(self, name: str, value: bytes | io.IOBase | io.BytesIO) -> None:
+        super().__init__(name=name, value=value)
 
 
 @x_prefixed
-class XCustomTextMetadata(CustomTextMetadata): ...
+class XCustomTextMetadata(CustomTextMetadata):
+    # reimpl just to please coverage
+    def __init__(self, name: str, value: str) -> None:
+        super().__init__(name=name, value=value)
 
 
-MANDATORY_ZIM_METADATA_KEYS = StandardMetadataList.get_reserved_names()
+MANDATORY_ZIM_METADATA_KEYS: list[str] = StandardMetadataList.get_reserved_names()
 
 
 DEFAULT_DEV_ZIM_METADATA = StandardMetadataList(

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -43,25 +43,7 @@ def test_mime_overrides(svg_image):
             assert get_content_mimetype(fh.read(64)) == expected_mime
 
 
-def test_delete_callback_with_cb(tmp_path):
-    class Store:
-        called = 0
-
-    def cb(*args):  # noqa: ARG001
-        Store.called += 1
-
-    fpath = tmp_path.joinpath("my-file")
-    with open(fpath, "w") as fh:
-        fh.write("content")
-
-    delete_callback(fpath, cb, fpath.name)
-
-    assert not fpath.exists()
-    assert Store.called
-    assert Store.called == 1
-
-
-def test_delete_callback_without_cb(tmp_path):
+def test_delete_callback(tmp_path):
     fpath = tmp_path.joinpath("my-file")
     with open(fpath, "w") as fh:
         fh.write("content")

--- a/tests/inputs/test_inputs.py
+++ b/tests/inputs/test_inputs.py
@@ -9,17 +9,17 @@ import pytest
 
 import zimscraperlib
 from zimscraperlib.constants import CONTACT
-from zimscraperlib.constants import (
-    MAXIMUM_DESCRIPTION_METADATA_LENGTH as MAX_DESC_LENGTH,
-)
-from zimscraperlib.constants import (
-    MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH as MAX_LONG_DESC_LENGTH,
-)
 from zimscraperlib.constants import NAME as PROJECT_NAME
 from zimscraperlib.inputs import (
     compute_descriptions,
     compute_tags,
     handle_user_provided_file,
+)
+from zimscraperlib.zim.metadata import (
+    MAXIMUM_DESCRIPTION_METADATA_LENGTH as MAX_DESC_LENGTH,
+)
+from zimscraperlib.zim.metadata import (
+    MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH as MAX_LONG_DESC_LENGTH,
 )
 
 

--- a/tests/zim/conftest.py
+++ b/tests/zim/conftest.py
@@ -107,6 +107,6 @@ def counters():
 
 @pytest.fixture
 def ignore_metadata_conventions():
-    zimscraperlib.zim.metadata.check_metadata_conventions = False
+    zimscraperlib.zim.metadata.APPLY_RECOMMENDATIONS = False
     yield
-    zimscraperlib.zim.metadata.check_metadata_conventions = True
+    zimscraperlib.zim.metadata.APPLY_RECOMMENDATIONS = True

--- a/tests/zim/conftest.py
+++ b/tests/zim/conftest.py
@@ -3,6 +3,8 @@
 
 import pytest
 
+import zimscraperlib.zim.metadata
+
 
 @pytest.fixture(scope="function")
 def html_str():
@@ -101,3 +103,10 @@ def counters():
         "application/xml": 1,
         "image/svg+xml": 5,
     }
+
+
+@pytest.fixture
+def ignore_metadata_conventions():
+    zimscraperlib.zim.metadata.check_metadata_conventions = False
+    yield
+    zimscraperlib.zim.metadata.check_metadata_conventions = True

--- a/tests/zim/test_fs.py
+++ b/tests/zim/test_fs.py
@@ -142,7 +142,7 @@ try:
         illustration="{png_image.name}",
         title="Test ZIM",
         description="A test ZIM",
-        redirects_file="{build_data["redirects_file"]}")
+        redirects_file=pathlib.Path("{build_data["redirects_file"]}"))
 except Exception as exc:
     print(exc)
 finally:

--- a/tests/zim/test_metadata.py
+++ b/tests/zim/test_metadata.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import base64
+import dataclasses
+import datetime
+import io
+import pathlib
 import re
-from collections.abc import Iterable
+from typing import NamedTuple
 
 import pytest
 
@@ -9,55 +14,437 @@ from zimscraperlib.zim import metadata
 
 
 @pytest.mark.parametrize(
-    "name, value",
+    "value",
     [
-        ("Language", "fra"),
-        ("Language", "fra,eng"),
-        ("Language", ["fra", "eng"]),
-        ("Other", "not_an_iso_639_3_code"),
+        ("fra"),
+        ("eng"),
+        ("bam"),
+        ("fra,eng"),
+        ("eng, fra"),
+        ("fra,eng,bam"),
+        (["fra", "eng"]),
+        ("fra, eng"),  # codes are automatically cleaned-up
+        ("eng,  \r"),  # codes are automatically cleaned-up
+        (["fra", "  "]),  # codes are automatically cleaned-up
     ],
 )
-def test_validate_language_valid(name: str, value: Iterable[str] | str):
-    metadata.validate_language(name, value)
+def test_validate_language_valid(value: list[str] | str):
+    assert metadata.LanguageMetadata(value)
 
 
 @pytest.mark.parametrize(
-    "name, value",
+    "value,error",
     [
-        ("Language", "fr"),
-        ("Language", "fra;eng"),
-        ("Language", "fra, eng"),
+        ("", "Missing value for mandatory metadata"),
+        ("fr", "is not ISO-639-3"),
+        ("en", "is not ISO-639-3"),
+        ("xxx", "is not ISO-639-3"),
+        ("rmr", "is not ISO-639-3"),
+        ("fra,en,bam", "is not ISO-639-3"),
+        ("fra;eng", "is not ISO-639-3"),
+        ("fra,fra", "Duplicate codes not allowed in Language metadata"),
+        (["fra", "fra"], "Duplicate codes not allowed in Language metadata"),
+        ([], "Missing value for mandatory metadata"),
+        (["  ", "\t"], "Missing value for mandatory Language metadata"),
+        ("  , ", "Missing value for mandatory Language metadata"),
+        (["fra", 1], "Invalid type(s) found in Iterable:"),
+        (["fra", b"1"], "Invalid type(s) found in Iterable:"),
+        (["fra", 1, b"1"], "Invalid type(s) found in Iterable:"),
     ],
 )
-def test_validate_language_invalid(name: str, value: Iterable[str] | str):
-    with pytest.raises(ValueError, match=re.escape("is not ISO-639-3")):
-        metadata.validate_language(name, value)
+def test_validate_language_invalid(value: list[str] | str, error: str):
+    with pytest.raises(ValueError, match=re.escape(error)):
+        assert metadata.LanguageMetadata(value)
 
 
 @pytest.mark.parametrize(
     "tags, is_valid",
     [
-        pytest.param("", True, id="empty_string"),
-        pytest.param("tag1", True, id="empty_string"),
+        pytest.param("wikipedia", True, id="simple_tag"),
         pytest.param("taaaag1", True, id="many_letters"),
-        pytest.param("tag1;tag2", True, id="semi_colon_distinct_1"),
-        pytest.param("tag2;tag2", False, id="semi_colon_identical"),
+        pytest.param("wikipedia;   ", True, id="remove_empty_values"),
+        pytest.param("wikipedia ;  football", True, id="semi_colon_distinct_1"),
+        pytest.param("football;football", True, id="semi_colon_identical"),
         pytest.param("tag,1;tug,1", True, id="semi_colon_distinct_2"),
         pytest.param(
-            "tag1,tag2", True, id="comma"
+            "wikipedia,football", True, id="comma"
         ),  # we cannot say that this ought to be a tags separator
-        pytest.param({"tag1"}, True, id="one_tag_in_set"),
-        pytest.param({"tag1", "tag2"}, True, id="two_tags_in_set"),
-        pytest.param(1, False, id="one_int"),
-        pytest.param(None, False, id="none_value"),
-        pytest.param(["tag1", "tag2"], True, id="two_distinct"),
-        pytest.param(["tag1", "tag1"], False, id="two_identical"),
-        pytest.param(["tag1", 1], False, id="int_in_list"),
+        pytest.param({"wikipedia"}, True, id="one_tag_in_set"),
+        pytest.param({"wikipedia", "football"}, True, id="two_tags_in_set"),
+        pytest.param(["wikipedia", "football"], True, id="two_distinct"),
+        pytest.param(["wikipedia", "wikipedia"], True, id="two_identical"),
     ],
 )
-def test_validate_tags(tags, is_valid):
+def test_validate_tags_valid(tags, is_valid):
     if is_valid:
-        metadata.validate_tags("Tags", tags)
+        metadata.TagsMetadata(tags)
     else:
-        with pytest.raises(ValueError):
-            metadata.validate_tags("Tags", tags)
+        with pytest.raises((ValueError, TypeError)):
+            metadata.TagsMetadata(tags)
+
+
+@pytest.mark.parametrize(
+    "value, error",
+    [
+        pytest.param("", "Cannot set empty metadata", id="empty_string"),
+        pytest.param(1, "Unexpected type passed to TagsMetadata: int", id="one_int"),
+        pytest.param(
+            None, "Unexpected type passed to TagsMetadata: NoneType", id="none_value"
+        ),
+        pytest.param(
+            ["wikipedia", 1], "Invalid type(s) found in Iterable: int", id="int_in_list"
+        ),
+    ],
+)
+def test_validate_tags_invalid(value: list[str] | str, error: str):
+    with pytest.raises(ValueError, match=re.escape(error)):
+        metadata.TagsMetadata(value)
+
+
+def test_validate_dedup_tags():
+    assert (
+        metadata.TagsMetadata("  wikipedia  \t   ;   wikipedia").libzim_value
+        == b"wikipedia"
+    )
+
+
+def test_validate_short_title_check_enabled():
+    assert metadata.TitleMetadata("T" * 30)
+
+
+def test_validate_short_grapheme_title_check_enabled():
+    assert metadata.TitleMetadata("में" * 30)
+
+
+def test_validate_too_long_title_check_enabled():
+    with pytest.raises(ValueError, match="Title is too long"):
+        assert metadata.TitleMetadata("T" * 31)
+
+
+def test_validate_too_long_title_check_disabled(
+    ignore_metadata_conventions,  # noqa: ARG001
+):
+    assert metadata.TitleMetadata("T" * 31)
+
+
+def test_validate_short_description_check_enabled():
+    assert metadata.DescriptionMetadata("T" * 80)
+
+
+def test_validate_short_grapheme_description_check_enabled():
+    assert metadata.DescriptionMetadata("में" * 80)
+
+
+def test_validate_too_long_description_check_enabled():
+    with pytest.raises(ValueError, match="Description is too long"):
+        assert metadata.DescriptionMetadata("T" * 81)
+
+
+def test_validate_too_long_description_check_disabled(
+    ignore_metadata_conventions,  # noqa: ARG001
+):
+    assert metadata.DescriptionMetadata("T" * 81)
+
+
+def test_validate_short_longdescription_check_enabled():
+    assert metadata.LongDescriptionMetadata("T" * 4000)
+
+
+def test_validate_short_grapheme_longdescription_check_enabled():
+    assert metadata.LongDescriptionMetadata("में" * 4000)
+
+
+def test_validate_too_long_longdescription_check_enabled():
+    with pytest.raises(ValueError, match="Description is too long"):
+        assert metadata.LongDescriptionMetadata("T" * 4001)
+
+
+def test_validate_too_long_longdescription_check_disabled(
+    ignore_metadata_conventions,  # noqa: ARG001
+):
+    assert metadata.LongDescriptionMetadata("T" * 4001)
+
+
+def test_validate_date_datetime_date():
+    assert metadata.DateMetadata(datetime.date(2024, 12, 11))
+
+
+def test_validate_date_datetime_datetime():
+    assert metadata.DateMetadata(
+        datetime.datetime(2024, 12, 11, 0, 0, 0, tzinfo=datetime.UTC)
+    )
+
+
+@pytest.mark.parametrize("value", [("9999-99-99"), ("2023/02/29"), ("1969-13-31")])
+def test_validate_date_invalid_date(value):
+    with pytest.raises(ValueError, match="Invalid date format"):
+        metadata.DateMetadata(value)
+
+
+def test_validate_illustration_invalid_name():
+    with pytest.raises(ValueError, match="Illustration metadata has improper name"):
+        metadata.IllustrationMetadata("Illustration_48x48_at_1", b"")
+
+
+def test_validate_illustration_not_squared():
+    with pytest.raises(ValueError, match="Illustration is not squared"):
+        metadata.IllustrationMetadata("Illustration_48x96@1", b"")
+
+
+def test_validate_illustration_wrong_sizes(png_image2):
+    with open(png_image2, "rb") as fh:
+        png_data = fh.read()
+    with pytest.raises(
+        ValueError, match="Illustration_48x48@1 is not a valid 48x48 PNG Image"
+    ):
+        metadata.IllustrationMetadata("Illustration_48x48@1", png_data)
+
+
+def test_blank_metadata():
+    with pytest.raises(ValueError, match="Cannot set empty metadata"):
+        metadata.Metadata("Blank", b"")
+
+
+class MetadataInitConfig(NamedTuple):
+    a_type: type
+    nb_args: int
+
+
+@pytest.fixture(
+    params=[
+        MetadataInitConfig(metadata.Metadata, 2),
+        MetadataInitConfig(metadata._TextMetadata, 2),
+        MetadataInitConfig(metadata.CustomTextMetadata, 2),
+        MetadataInitConfig(metadata.CustomMetadata, 2),
+        MetadataInitConfig(metadata._MandatoryTextMetadata, 2),
+        MetadataInitConfig(metadata._MandatoryMetadata, 2),
+        MetadataInitConfig(metadata.TitleMetadata, 1),
+        MetadataInitConfig(metadata.DescriptionMetadata, 1),
+        MetadataInitConfig(metadata.LongDescriptionMetadata, 1),
+        MetadataInitConfig(metadata.DateMetadata, 1),
+        MetadataInitConfig(metadata.IllustrationMetadata, 2),
+        MetadataInitConfig(metadata.LanguageMetadata, 1),
+        MetadataInitConfig(metadata.TagsMetadata, 1),
+        MetadataInitConfig(metadata.NameMetadata, 1),
+        MetadataInitConfig(metadata.CreatorMetadata, 1),
+        MetadataInitConfig(metadata.PublisherMetadata, 1),
+        MetadataInitConfig(metadata.ScraperMetadata, 1),
+        MetadataInitConfig(metadata.FlavourMetadata, 1),
+        MetadataInitConfig(metadata.SourceMetadata, 1),
+        MetadataInitConfig(metadata.LicenseMetadata, 1),
+        MetadataInitConfig(metadata.RelationMetadata, 1),
+    ]
+)
+def metadata_init(request: pytest.FixtureRequest) -> MetadataInitConfig:
+    return request.param
+
+
+def test_none_metadata_two_args(metadata_init: MetadataInitConfig):
+    with pytest.raises(
+        ValueError,
+        match=f"Unexpected type passed to {metadata_init.a_type.__qualname__}: "
+        "NoneType",
+    ):
+        if metadata_init.nb_args == 2:
+            metadata_init.a_type(
+                "Foo",
+                None,  # pyright: ignore[reportArgumentType]
+            )
+        elif metadata_init.nb_args == 1:
+            metadata_init.a_type(None)
+
+
+@pytest.mark.parametrize(
+    "a_type",
+    [
+        (metadata.Metadata),
+        (metadata.CustomTextMetadata),
+        (metadata._TextMetadata),
+        (metadata._MandatoryMetadata),
+    ],
+)
+def test_reserved_counter_metadata(a_type: type):
+    with pytest.raises(ValueError, match="Counter cannot be set. libzim sets it."):
+        a_type("Counter", b"Foo")
+
+
+@pytest.mark.parametrize(
+    "metadata_name",
+    [
+        ("Name"),
+        ("Language"),
+        ("Title"),
+        ("Creator"),
+        ("Publisher"),
+        ("Date"),
+        ("Illustration_48x48@1"),
+        ("Illustration_96x96@1"),
+        ("Description"),
+        ("LongDescription"),
+        ("Tags"),
+        ("Scraper"),
+        ("Flavour"),
+        ("Source"),
+        ("License"),
+        ("Relation"),
+    ],
+)
+@pytest.mark.parametrize(
+    "metadata_type",
+    [
+        (metadata.CustomMetadata),
+        (metadata.CustomTextMetadata),
+    ],
+)
+def test_reserved_names(metadata_name: str, metadata_type: type):
+    with pytest.raises(ValueError, match="It is not allowed to use"):
+        metadata_type(metadata_name, b"a value")
+
+
+def test_mandatory_value(metadata_init: MetadataInitConfig):
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "is not a valid 48x48 PNG Image"
+            if metadata_init.a_type == metadata.IllustrationMetadata
+            else (
+                "Invalid date format, not matching regex"
+                if metadata_init.a_type == metadata.DateMetadata
+                else "Cannot set empty metadata|Missing value for mandatory metadata"
+            )
+        ),
+    ):
+        if metadata_init.nb_args == 2:
+            metadata_init.a_type(
+                (
+                    "Foo"
+                    if metadata_init.a_type != metadata.IllustrationMetadata
+                    else "Illustration_48x48@1"
+                ),
+                b"",
+            )
+        elif metadata_init.nb_args == 1:
+            metadata_init.a_type(b"")
+
+
+def test_clean_value(metadata_init: MetadataInitConfig):
+    raw_value = b"\t\n\r\n \tA val \t\awith  \bcontrol chars\v\n"
+    clean_value = b"A val \twith  control chars"
+    if metadata_init.a_type in (
+        # some types do not support the raw value
+        metadata.IllustrationMetadata,
+        metadata.LanguageMetadata,
+        metadata.DateMetadata,
+        # and binary types are not cleaned-up
+        metadata.Metadata,
+        metadata.CustomMetadata,
+        metadata._MandatoryMetadata,
+    ):
+        pytest.skip("unsupported configuration")  # ignore these test cases
+    if metadata_init.nb_args == 2:
+        assert metadata_init.a_type(("Foo"), raw_value).libzim_value == clean_value
+    elif metadata_init.nb_args == 1:
+        assert metadata_init.a_type(raw_value).libzim_value == clean_value
+
+
+# @pytest.mark.parametrize(
+#     "metadata, expected_value",
+#     [
+#         (metadata.Metadata("Foo", b"a value"), b"a value"),
+#         (metadata.Metadata("Foo", io.BytesIO(b"a value")), b"a value"),
+#         (metadata.DescriptionMetadata(io.BytesIO(b"a value")), b"a value"),
+#         (metadata.DescriptionMetadata(b"a value"), b"a value"),
+#         (metadata.DescriptionMetadata("a value"), b"a value"),
+#         (metadata.IllustrationMetadata(png), b"a value"),
+#     ],
+# )
+def test_libzim_bytes_value(metadata_init: MetadataInitConfig, png_image: pathlib.Path):
+    if metadata_init.nb_args == 2:
+        if metadata_init.a_type == metadata.IllustrationMetadata:
+            with open(png_image, "rb") as fh:
+                png_data = fh.read()
+            assert (
+                metadata.IllustrationMetadata(
+                    "Illustration_48x48@1", png_data
+                ).libzim_value
+                == png_data
+            )
+        else:
+            assert metadata_init.a_type("Foo", b"a value").libzim_value == b"a value"
+    elif metadata_init.nb_args == 1:
+        if metadata_init.a_type == metadata.DateMetadata:
+            assert metadata_init.a_type(b"2023-12-11").libzim_value == b"2023-12-11"
+        elif metadata_init.a_type == metadata.LanguageMetadata:
+            assert metadata_init.a_type(b"fra,eng").libzim_value == b"fra,eng"
+        else:
+            assert metadata_init.a_type(b"a value").libzim_value == b"a value"
+
+
+def test_libzim_io_bytesio_value(
+    metadata_init: MetadataInitConfig, png_image: pathlib.Path
+):
+    if metadata_init.nb_args == 2:
+        if metadata_init.a_type == metadata.IllustrationMetadata:
+            with open(png_image, "rb") as fh:
+                png_data = fh.read()
+            assert (
+                metadata.IllustrationMetadata(
+                    "Illustration_48x48@1", io.BytesIO(png_data)
+                ).libzim_value
+                == png_data
+            )
+        else:
+            assert (
+                metadata_init.a_type("Foo", io.BytesIO(b"a value")).libzim_value
+                == b"a value"
+            )
+    elif metadata_init.nb_args == 1:
+        if metadata_init.a_type == metadata.DateMetadata:
+            pass  # Not supported
+        elif metadata_init.a_type == metadata.LanguageMetadata:
+            assert (
+                metadata_init.a_type(io.BytesIO(b"fra,eng")).libzim_value == b"fra,eng"
+            )
+        else:
+            assert (
+                metadata_init.a_type(io.BytesIO(b"a value")).libzim_value == b"a value"
+            )
+
+
+def test_std_metadata_values():
+    test_value = dataclasses.replace(metadata.DEFAULT_DEV_ZIM_METADATA)
+    test_value.License = metadata.LicenseMetadata("Creative Commons CC0")
+    values = test_value.values()
+    assert len(values) == 9
+
+    expected_values: list[metadata.Metadata] = [
+        metadata.LicenseMetadata("Creative Commons CC0"),
+        metadata.NameMetadata("Test Name"),
+        metadata.TitleMetadata("Test Title"),
+        metadata.CreatorMetadata("Test Creator"),
+        metadata.PublisherMetadata("Test Publisher"),
+        metadata.DateMetadata("2023-01-01"),
+        metadata.DescriptionMetadata("Test Description"),
+        metadata.LanguageMetadata("fra"),
+        # blank 48x48 transparent PNG
+        metadata.IllustrationMetadata(
+            "Illustration_48x48@1",
+            base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwAQMAAABtzGvEAAAAGXRFWHRTb2Z0d2FyZQBB"
+                "ZG9iZSBJbWFnZVJlYWR5ccllPAAAAANQTFRFR3BMgvrS0gAAAAF0Uk5TAEDm2GYAAAAN"
+                "SURBVBjTY2AYBdQEAAFQAAGn4toWAAAAAElFTkSuQmCC"
+            ),
+        ),
+    ]
+    for value in values:
+        found = False
+        for expected_value in expected_values:
+            if value.__class__ == expected_value.__class__:
+                assert value.value == expected_value.value
+                found = True
+                break
+        if not found:
+            pytest.fail(
+                f"Did not found matching expected values for {value.name} metadata"
+            )

--- a/tests/zim/test_typing.py
+++ b/tests/zim/test_typing.py
@@ -1,0 +1,40 @@
+from zimscraperlib.typing import Callback
+
+
+class GlobalCounter:
+    count: int = 0
+
+
+def update_counter() -> int:
+    GlobalCounter.count += 1
+    return GlobalCounter.count
+
+
+def update_counter_args(bump: int) -> int:
+    GlobalCounter.count += bump
+    return GlobalCounter.count
+
+
+def update_counter_kwargs(*, bump: int) -> int:
+    GlobalCounter.count += bump
+    return GlobalCounter.count
+
+
+def update_counter_args_and_kwargs(bump: int, *, factor: int) -> int:
+    GlobalCounter.count += bump * factor
+    return GlobalCounter.count
+
+
+def test_callback_init():
+    assert Callback(update_counter)
+    assert Callback(update_counter).callable
+    GlobalCounter.count = 0
+    assert GlobalCounter.count == 0
+    Callback(update_counter_args, args=(1,)).call()
+    assert GlobalCounter.count == 1
+    Callback(update_counter_args, kwargs={"bump": 1}).call()
+    assert GlobalCounter.count == 2
+    Callback(update_counter_kwargs, kwargs={"bump": 1}).call()
+    assert GlobalCounter.count == 3
+    Callback(update_counter_args_and_kwargs, args=(1,), kwargs={"factor": 2}).call()
+    assert GlobalCounter.count == 5

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import base64
-import datetime
 import io
 import logging
 import pathlib
@@ -14,19 +12,37 @@ import subprocess
 import sys
 import tempfile
 import time
+from typing import NamedTuple
 from unittest.mock import call, patch
 
 import pytest
 from libzim.writer import Compression  # pyright: ignore
 
-from zimscraperlib.constants import (
-    DEFAULT_DEV_ZIM_METADATA,
-    MANDATORY_ZIM_METADATA_KEYS,
-    UTF8,
-)
+from zimscraperlib.constants import UTF8
 from zimscraperlib.download import save_large_file, stream_file
 from zimscraperlib.filesystem import delete_callback
 from zimscraperlib.zim import Archive, Creator, StaticItem, URLItem
+from zimscraperlib.zim.metadata import (
+    DEFAULT_DEV_ZIM_METADATA,
+    CreatorMetadata,
+    CustomMetadata,
+    CustomTextMetadata,
+    DateMetadata,
+    DescriptionMetadata,
+    FlavourMetadata,
+    IllustrationMetadata,
+    LanguageMetadata,
+    LicenseMetadata,
+    LongDescriptionMetadata,
+    Metadata,
+    NameMetadata,
+    PublisherMetadata,
+    ScraperMetadata,
+    SourceMetadata,
+    StandardMetadataList,
+    TagsMetadata,
+    TitleMetadata,
+)
 from zimscraperlib.zim.providers import FileLikeProvider, URLProvider
 
 
@@ -60,7 +76,7 @@ def test_zim_creator(tmp_path, png_image, html_file, html_str: str, html_str_cn:
     with open(png_image, "rb") as fh:
         png_data = fh.read()
     with Creator(fpath, main_path).config_dev_metadata(
-        Tags=tags, Illustration_48x48_at_1=png_data
+        [TagsMetadata(tags), IllustrationMetadata("Illustration_48x48@1", png_data)]
     ) as creator:
         # verbatim HTML from string
         creator.add_item_for("welcome", "wel", content=html_str, is_front=True)
@@ -92,8 +108,10 @@ def test_zim_creator(tmp_path, png_image, html_file, html_str: str, html_str_cn:
     assert fpath.exists()
 
     reader = Archive(fpath)
-    assert reader.get_text_metadata("Title") == DEFAULT_DEV_ZIM_METADATA["Title"]
-    assert reader.get_text_metadata("Language") == DEFAULT_DEV_ZIM_METADATA["Language"]
+    assert reader.get_text_metadata("Title") == DEFAULT_DEV_ZIM_METADATA.Title.value
+    assert (
+        reader.get_text_metadata("Language") == DEFAULT_DEV_ZIM_METADATA.Language.value
+    )
     assert reader.get_text_metadata("Tags") == tags
     assert reader.main_entry.get_item().path == f"{main_path}"
     # make sure we have our image
@@ -134,7 +152,7 @@ def test_create_without_workaround(tmp_path):
 
 def test_noindexlanguage(tmp_path):
     fpath = tmp_path / "test.zim"
-    creator = Creator(fpath, "welcome").config_dev_metadata(Language="bam")
+    creator = Creator(fpath, "welcome").config_dev_metadata(LanguageMetadata("bam"))
     creator.config_indexing(False)
     with creator as creator:
         creator.add_item(StaticItem(path="welcome", content="hello"))
@@ -536,20 +554,6 @@ def test_without_metadata(tmp_path):
         Creator(tmp_path, "").start()
 
 
-def test_check_metadata(tmp_path):
-    with pytest.raises(ValueError, match="Counter cannot be set"):
-        Creator(tmp_path, "").config_dev_metadata(Counter=1).start()
-
-    with pytest.raises(ValueError, match="Invalid type for Foo"):
-        Creator(tmp_path, "").config_dev_metadata(Foo=1).start()
-
-    with pytest.raises(ValueError, match="Description is too long."):
-        Creator(tmp_path, "").config_dev_metadata(Description="T" * 90).start()
-
-    with pytest.raises(ValueError, match="LongDescription is too long."):
-        Creator(tmp_path, "").config_dev_metadata(LongDescription="T" * 5000).start()
-
-
 @pytest.mark.parametrize(
     "tags",
     [
@@ -575,42 +579,62 @@ def test_start_logs_metadata_log_contents(mocked_logger, png_image, tags, tmp_pa
     fpath = tmp_path / "test_config.zim"
     with open(png_image, "rb") as fh:
         png_data = fh.read()
-    creator = Creator(fpath, "", disable_metadata_checks=True).config_metadata(
-        Name="wikipedia_fr_football",
-        Title="English Wikipedia",
-        Creator="English speaking Wikipedia contributors",
-        Publisher="Wikipedia user Foobar",
-        Date="2009-11-21",
-        Description="All articles (without images) from the english Wikipedia",
-        LongDescription="This ZIM file contains all articles (without images)"
-        " from the english Wikipedia by 2009-11-10. The topics are...",
-        Language="eng",
-        License="CC-BY",
-        Tags=tags,
-        Flavour="nopic",
-        Source="https://en.wikipedia.org/",
-        Scraper="mwoffliner 1.2.3",
-        Illustration_48x48_at_1=png_data,
-        TestMetadata="Test Metadata",
+    creator = Creator(fpath, "", check_metadata_conventions=False).config_metadata(
+        StandardMetadataList(
+            Name=NameMetadata("wikipedia_fr_football"),
+            Title=TitleMetadata("English Wikipedia"),
+            Creator=CreatorMetadata("English speaking Wikipedia contributors"),
+            Publisher=PublisherMetadata("Wikipedia user Foobar"),
+            Date=DateMetadata("2009-11-21"),
+            Description=DescriptionMetadata(
+                "All articles (without images) from the english Wikipedia"
+            ),
+            LongDescription=LongDescriptionMetadata(
+                "This ZIM file contains all articles (without images)"
+                " from the english Wikipedia by 2009-11-10. The topics are..."
+            ),
+            Language=LanguageMetadata("eng"),
+            License=LicenseMetadata("CC-BY"),
+            Tags=TagsMetadata(tags),
+            Flavour=FlavourMetadata("nopic"),
+            Source=SourceMetadata("https://en.wikipedia.org/"),
+            Scraper=ScraperMetadata("mwoffliner 1.2.3"),
+            Illustration_48x48_at_1=IllustrationMetadata(
+                "Illustration_48x48@1", png_data
+            ),
+        ),
+        [CustomTextMetadata("TestMetadata", "Test Metadata")],
+        fail_on_missing_prefix_in_extras=False,
     )
 
-    class NotPrintable:
+    class NotPrintable(str):
         def __str__(self):
             raise ValueError("Not printable I said")
 
     creator._metadata.update(
         {
-            "Illustration_96x96@1": b"%PDF-1.5\n%\xe2\xe3\xcf\xd3",
-            "Chars": b"\xc5\xa1\xc9\x94\xc9\x9b",
-            "Chars-32": b"\xff\xfe\x00\x00a\x01\x00\x00T\x02\x00\x00[\x02\x00\x00",
-            "Video": b"\x00\x00\x00 ftypisom\x00\x00\x02\x00isomiso2avc1mp41\x00",
-            "Toupie": NotPrintable(),
-        }
+            "Illustration_96x96@1": Metadata(
+                "Illustration_96x96@1", b"%PDF-1.5\n%\xe2\xe3\xcf\xd3"
+            ),
+            "Chars": Metadata("Chars", b"\xc5\xa1\xc9\x94\xc9\x9b"),
+            "Chars-32": Metadata(
+                "Chars-32", b"\xff\xfe\x00\x00a\x01\x00\x00T\x02\x00\x00[\x02\x00\x00"
+            ),
+            "Video": Metadata(
+                "Video", b"\x00\x00\x00 ftypisom\x00\x00\x02\x00isomiso2avc1mp41\x00"
+            ),
+            "Toupie": CustomTextMetadata("Toupie", NotPrintable("value")),
+        }  # intentionaly bad, to handle case where user does bad things
     )
+    # intentionaly bad, to handle case where user does bad things
+    creator._metadata["Relation"] = None  # pyright: ignore[reportArgumentType]
+    creator._metadata["BadRawValue"] = "Value"  # pyright: ignore[reportArgumentType]
+
     creator._log_metadata()
     # /!\ this must be alpha sorted
     mocked_logger.debug.assert_has_calls(
         [
+            call("Metadata: BadRawValue is improper metadata type: str: Value"),
             call("Metadata: Chars = šɔɛ"),
             call(
                 "Metadata: Chars-32 is a 16 bytes text/plain blob "
@@ -624,10 +648,7 @@ def test_start_logs_metadata_log_contents(mocked_logger, png_image, tags, tmp_pa
             ),
             call("Metadata: Flavour = nopic"),
             call("Metadata: Illustration_48x48@1 is a 3274 bytes 48x48px PNG Image"),
-            call(
-                "Metadata: Illustration_96x96@1 is a 14 bytes "
-                "application/pdf blob not recognized as an Image"
-            ),
+            call("Metadata: Illustration_96x96@1 is a 14 bytes application/pdf blob"),
             call("Metadata: Language = eng"),
             call("Metadata: License = CC-BY"),
             call(
@@ -637,21 +658,27 @@ def test_start_logs_metadata_log_contents(mocked_logger, png_image, tags, tmp_pa
             ),
             call("Metadata: Name = wikipedia_fr_football"),
             call("Metadata: Publisher = Wikipedia user Foobar"),
-            call("Metadata: Relation = None"),
+            call("Metadata: Relation is None"),
             call("Metadata: Scraper = mwoffliner 1.2.3"),
             call("Metadata: Source = https://en.wikipedia.org/"),
             call(f"Metadata: Tags = {tags}"),
             call("Metadata: TestMetadata = Test Metadata"),
             call("Metadata: Title = English Wikipedia"),
-            call("Metadata: Toupie is unexpected data type: NotPrintable"),
+            call(
+                "Metadata: Toupie is unexpected data type: "
+                "test_start_logs_metadata_log_contents.<locals>.NotPrintable"
+            ),
             call("Metadata: Video is a 33 bytes video/mp4 blob"),
         ]
     )
 
 
-def test_relax_metadata(tmp_path):
-    Creator(tmp_path, "", disable_metadata_checks=True).config_dev_metadata(
-        Description="T" * 90
+def test_relax_metadata(
+    tmp_path,
+    ignore_metadata_conventions,  # noqa: ARG001
+):
+    Creator(tmp_path, "", check_metadata_conventions=False).config_dev_metadata(
+        DescriptionMetadata("T" * 90)
     ).start()
 
 
@@ -679,22 +706,30 @@ def test_config_metadata(tmp_path, png_image, tags):
     with open(png_image, "rb") as fh:
         png_data = fh.read()
     creator = Creator(fpath, "").config_metadata(
-        Name="wikipedia_fr_football",
-        Title="English Wikipedia",
-        Creator="English speaking Wikipedia contributors",
-        Publisher="Wikipedia user Foobar",
-        Date="2009-11-21",
-        Description="All articles (without images) from the english Wikipedia",
-        LongDescription="This ZIM file contains all articles (without images)"
-        " from the english Wikipedia by 2009-11-10. The topics are...",
-        Language="eng",
-        License="CC-BY",
-        Tags=tags,
-        Flavour="nopic",
-        Source="https://en.wikipedia.org/",
-        Scraper="mwoffliner 1.2.3",
-        Illustration_48x48_at_1=png_data,
-        TestMetadata="Test Metadata",
+        StandardMetadataList(
+            Name=NameMetadata("wikipedia_fr_football"),
+            Title=TitleMetadata("English Wikipedia"),
+            Creator=CreatorMetadata("English speaking Wikipedia contributors"),
+            Publisher=PublisherMetadata("Wikipedia user Foobar"),
+            Date=DateMetadata("2009-11-21"),
+            Description=DescriptionMetadata(
+                "All articles (without images) from the english Wikipedia"
+            ),
+            LongDescription=LongDescriptionMetadata(
+                "This ZIM file contains all articles (without images)"
+                " from the english Wikipedia by 2009-11-10. The topics are..."
+            ),
+            Language=LanguageMetadata("eng"),
+            License=LicenseMetadata("CC-BY"),
+            Tags=TagsMetadata(tags),
+            Flavour=FlavourMetadata("nopic"),
+            Source=SourceMetadata("https://en.wikipedia.org/"),
+            Scraper=ScraperMetadata("mwoffliner 1.2.3"),
+            Illustration_48x48_at_1=IllustrationMetadata(
+                "Illustration_48x48@1", png_data
+            ),
+        ),
+        [CustomTextMetadata("X-TestMetadata", "Test Metadata")],
     )
     with creator:
         pass
@@ -720,48 +755,46 @@ def test_config_metadata(tmp_path, png_image, tags):
     )
     assert reader.get_text_metadata("Language") == "eng"
     assert reader.get_text_metadata("License") == "CC-BY"
-    assert (
-        reader.get_text_metadata("Tags")
-        == "wikipedia;_category:wikipedia;_pictures:no;_videos:no;"
-        "_details:yes;_ftindex:yes"
-    )
+    assert set(reader.get_text_metadata("Tags").split(";")) == set(
+        "wikipedia;_category:wikipedia;_pictures:no;_videos:no;"
+        "_details:yes;_ftindex:yes".split(";")
+    )  # order of tags is not guaranteed and does not matter
+    assert len(reader.get_text_metadata("Tags").split(";")) == 6
     assert reader.get_text_metadata("Flavour") == "nopic"
     assert reader.get_text_metadata("Source") == "https://en.wikipedia.org/"
     assert reader.get_text_metadata("Scraper") == "mwoffliner 1.2.3"
     assert reader.get_metadata("Illustration_48x48@1") == png_data
-    assert reader.get_text_metadata("TestMetadata") == "Test Metadata"
+    assert reader.get_text_metadata("X-TestMetadata") == "Test Metadata"
 
 
 def test_config_metadata_control_characters(tmp_path):
     fpath = tmp_path / "test_config.zim"
     creator = Creator(fpath, "").config_dev_metadata(
-        Description="\t\n\r\n \tA description \awith  \bcontrol characters\v",
-        LongDescription="A description \rwith \a\ncontrol characters\tsss\t\n\r\n \t",
-        Creator="  A creator ",
+        [
+            DescriptionMetadata(
+                "\t\n\r\n \tA description \awith  \bcontrol characters\v"
+            ),
+            LongDescriptionMetadata(
+                "A description \rwith \a\ncontrol characters\tsss\t\n\r\n \t"
+            ),
+            CreatorMetadata("  A creator "),
+        ]
     )
-    assert creator._metadata["Description"] == "A description with  control characters"
-    assert (
-        creator._metadata["LongDescription"]
-        == "A description \rwith \ncontrol characters\tsss"
-    )
-    assert creator._metadata["Creator"] == "A creator"
     with creator:
         creator.add_metadata(
-            "Description_1",
-            "\t\n\r\n \tA description \awith  \bcontrol characters\v",
+            CustomTextMetadata(
+                "Description_1",
+                "\t\n\r\n \tA description \awith  \bcontrol characters\v",
+            )
         )
         creator.add_metadata(
-            "LongDescription_1",
-            "A description \rwith \a\ncontrol characters\tsss\t\n\r\n \t",
+            CustomTextMetadata(
+                "LongDescription_1",
+                "A description \rwith \a\ncontrol characters\tsss\t\n\r\n \t",
+            )
         )
-        creator.add_metadata(
-            "Creator_1",
-            "  A creator ",
-        )
-        creator.add_metadata(
-            "Binary1",
-            bytes.fromhex("01FA"),
-        )
+        creator.add_metadata(CustomTextMetadata("Creator_1", "  A creator "))
+        creator.add_metadata(CustomMetadata("Binary1", bytes.fromhex("01FA")))
         pass
 
     assert fpath.exists()
@@ -788,83 +821,94 @@ def test_config_metadata_control_characters(tmp_path):
     assert bytes.hex(reader.get_metadata("Binary1")) == "01fa"
 
 
-@pytest.mark.parametrize(
-    "name,value,valid",
-    [
-        ("Name", 4, False),
-        ("Title", 4, False),
-        ("Creator", 4, False),
-        ("Publisher", 4, False),
-        ("Description", 4, False),
-        ("LongDescription", 4, False),
-        ("License", 4, False),
-        ("Relation", 4, False),
-        ("Relation", 4, False),
-        ("Flavour", 4, False),
-        ("Source", 4, False),
-        ("Scraper", 4, False),
-        ("Title", "में" * 30, True),
-        ("Title", "X" * 31, False),
-        ("Date", 4, False),
-        ("Date", datetime.datetime.now(), True),  # noqa: DTZ005
-        ("Date", datetime.datetime(1969, 12, 31, 23, 59), True),  # noqa: DTZ001
-        ("Date", datetime.date(1969, 12, 31), True),
-        ("Date", datetime.date.today(), True),  # noqa: DTZ011
-        ("Date", "1969-12-31", True),
-        ("Date", "1969-13-31", False),
-        ("Date", "2023/02/29", False),
-        ("Date", "2023-55-99", False),
-        ("Language", "xxx", False),
-        ("Language", "rmr", False),
-        ("Language", "eng", True),
-        ("Language", "fra", True),
-        ("Language", "bam", True),
-        ("Language", "fr", False),
-        ("Language", "en", False),
-        ("Language", "fra,eng", True),
-        ("Language", "fra,eng,bam", True),
-        ("Language", "fra,en,bam", False),
-        ("Language", "eng,", False),
-        ("Language", "eng, fra", False),
-        ("Counter", "1", False),
-        ("Description", "में" * 80, True),
-        ("Description", "X" * 81, False),
-        ("LongDescription", "में" * 4000, True),
-        ("LongDescription", "X" * 4001, False),
-        ("Tags", 4, False),
-        ("Tags", ["wikipedia", 4, "football"], False),
-        ("Tags", ("wikipedia", "football"), True),
-        ("Tags", ["wikipedia", "football"], True),
-        ("Tags", "wikipedia;football", True),
-        # 1x1 PNG image
-        (
-            "Illustration_48x48@1",
-            base64.b64decode(
-                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBB"
-                "ZG9iZSBJbWFnZVJlYWR5ccllPAAAAA9JREFUeNpi+P//P0CAAQAF/gL+Lc6J7gAAAABJ"
-                "RU5ErkJggg=="
-            ),
-            False,
-        ),
-        (
-            "Illustration_48x48@1",
-            DEFAULT_DEV_ZIM_METADATA["Illustration_48x48_at_1"],
+class ExtraMetadataCase(NamedTuple):
+    extras: list[Metadata]
+    fail_on_missing_prefix: bool
+    id: str
+
+
+def __get_extra_metadata_case_id(case: ExtraMetadataCase) -> str:
+    return case.id
+
+
+@pytest.fixture(
+    params=[
+        ExtraMetadataCase(
+            [CustomTextMetadata("X-TestMetadata", "Test Metadata")],
             True,
+            id="good_prefix",
         ),
-        (
-            "Illustration_96x96@1",
-            DEFAULT_DEV_ZIM_METADATA["Illustration_48x48_at_1"],
+        ExtraMetadataCase(
+            [CustomTextMetadata("TestMetadata", "Test Metadata")],
             False,
+            id="bad_prefix",
         ),
-    ]
-    + [(name, "", False) for name in MANDATORY_ZIM_METADATA_KEYS],
+        ExtraMetadataCase(
+            [
+                CustomTextMetadata("X-TestMetadata", "Test Metadata"),
+                CustomTextMetadata("X-TestMetadata2", "Test Metadata"),
+            ],
+            True,
+            id="list_of_two_good_prefix",
+        ),
+        ExtraMetadataCase(
+            [
+                CustomTextMetadata("X-TestMetadata", "Test Metadata"),
+                CustomTextMetadata("TestMetadata2", "Test Metadata"),
+            ],
+            False,
+            id="list_with_one_bad_prefix",
+        ),
+    ],
+    ids=__get_extra_metadata_case_id,
 )
-def test_validate_metadata(tmp_path, name, value, valid):
-    if valid:
-        Creator(tmp_path / "_.zim", "").validate_metadata(name, value)
-    else:
-        with pytest.raises(ValueError):
-            Creator(tmp_path / "_.zim", "").validate_metadata(name, value)
+def metadata_extras(request: pytest.FixtureRequest):
+    yield request.param
+
+
+def test_metadata_extras(tmp_path, metadata_extras: ExtraMetadataCase):
+    Creator(tmp_path / "_.zim", "").config_metadata(
+        DEFAULT_DEV_ZIM_METADATA,
+        metadata_extras.extras,
+        fail_on_missing_prefix_in_extras=metadata_extras.fail_on_missing_prefix,
+    )
+
+
+def test_metadata_extras_dev(tmp_path, metadata_extras: ExtraMetadataCase):
+    Creator(tmp_path / "_.zim", "").config_dev_metadata(metadata_extras.extras)
+
+
+def test_metadata_extras_missing_prefix(tmp_path):
+    with pytest.raises(ValueError, match="does not starts with X- as expected"):
+        Creator(tmp_path / "_.zim", "").config_metadata(
+            DEFAULT_DEV_ZIM_METADATA,
+            [CustomTextMetadata("TestMetadata", "Test Metadata")],
+        )
+
+
+@pytest.mark.parametrize(
+    "name,metadata,expected_value",
+    [
+        pytest.param(
+            "X-Test",
+            CustomTextMetadata(
+                "X-Test", DEFAULT_DEV_ZIM_METADATA.Title.libzim_value.decode() + "Foo"
+            ),
+            DEFAULT_DEV_ZIM_METADATA.Title.libzim_value.decode() + "Foo",
+            id="simple_str",
+        ),
+        pytest.param("Tags", TagsMetadata(["tag1", "tag2"]), "tag1;tag2", id="tags"),
+    ],
+)
+def test_add_metadata(
+    tmp_path: pathlib.Path, name: str, metadata: Metadata, expected_value: str
+):
+    fpath = tmp_path / "test_blank.zim"
+    with Creator(fpath, "").config_dev_metadata() as creator:
+        creator.add_metadata(metadata)
+    assert fpath.exists()
+    reader = Archive(fpath)
+    assert reader.get_text_metadata(name) == expected_value
 
 
 def test_config_indexing(tmp_path):


### PR DESCRIPTION
Fix https://github.com/openzim/python-scraperlib/issues/205

This is a full rewrite of https://github.com/openzim/python-scraperlib/pull/217, so I've opened a new PR since changes since last review made no more sense from my PoV.

- add types for all metadata, one type per metadata name plus some generic ones for non-standard metadata
  - all types are responsible to validate metadata value at initialization time
  - validation checks for adherence to the ZIM specification and conventions are automated
  - cleanup of unwanted control characters and stripping white characters are **automated in all text metadata**
  - whenever possible, try to **automatically clean a "reasonably" bad metadata** (e.g. automaticall accept and remove duplicate tags - harmless - but not duplicate language codes - codes are supposed to be ordered, so it is a weird situation) ; this is an alignment of paradigm, because for some metadata the lib was permissive, while for other it was quite restrictive ; this PR tries to align this and **make the lib as permissive as possible**, avoiding to fail a scraper for something which could be automatically fixed
  - it is now possible to disable ZIM conventions checks with `zim.metadata.check_metadata_conventions`
- simplify `zim.creator.Creator.config_metadata` by using these types and been more strict:
  - add new `StandardMetadata` class for standard metadata, including list of mandatory one
  - by default, all non-standard metadata must start with `X-` prefix
    - this not yet an openZIM convention / specification, so it is possible to disable this check with `fail_on_missing_prefix` argument
- simplify `add_metadata`, use same metadata types
- simplify `zim.creator.Creator.start` with new types, and drop all metadata from memory after being passed to the libzim
- drop `zim.creator.convert_and_check_metadata` (not usefull anymore, simply use proper metadata type)
- move `MANDATORY_ZIM_METADATA_KEYS` and `DEFAULT_DEV_ZIM_METADATA` from `constants` to `zim.metadata` to avoid circular dependencies
- new `inputs.unique_values` utility function to compute the list of uniques values from a given list, but preserving initial list order
- in `__init__` of `zim.creator.Creator`, rename `disable_metadata_checks` to `check_metadata_conventions` for clarity and brevity
  - beware that this manipulate the global `zim.metadata.check_metadata_conventions`, so if you have many creator running in parallel, they can't have different settings, last one initialized will "win"

Nota:
- I've moved many tests from `tests/zim/test_zim_creator.py` to `tests/zim/test_metadata.py` since most checks are now done at metadata initialization instead of when `config_metadata` or `start` are called, but coverage is similar