### PR TITLE
Add missing direct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "beautifulsoup4>=4.9.3,<5.0",
   "lxml>=4.6.3,<6.0",
   "optimize-images>=1.3.6,<2.0",
-  # regex has no upper-bound due to "date-based" release numbers, no semver, so their
+  # regex has no upper-bound due to "date-based" release numbers, no semver, so their
   # promise is that they will never (or always) break the API, and the API is very
   # limited and we use only a very small subset of it.
   "regex>=2020.7.14",
@@ -28,7 +28,11 @@ dependencies = [
   "CairoSVG>=2.2.0,<3.0",
   "beartype==0.19.0",
   # youtube-dl should be updated as frequently as possible
-  "yt-dlp"
+  "yt-dlp",
+  "pillow>=7.0.0,<12.0",
+  "urllib3>=1.26.5,<2.3.0",
+  "piexif==1.1.3", # this dep is a nightmare in terms of release management, better pinned just like in optimize-images anyway
+  "idna>=2.5,<4.0"
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 


### PR DESCRIPTION
Fix #226 

I did not found more direct dependencies than what was listed in the issue.

Remarks:
- for pillow, I confirmed 7.0.0 is ok (tests are green) but last 6.x is not
- for urllib3, 1.26.5 is a minimum for tests to test ; they introduce breaking changes in minor so I restricted to < 2.3 ... to be updated regularly obviously
- for pixexif, I pinned a version like optimize-image did, this is a nightmare otherwise
- for idna, the range is relatively wide open, even if recent versions mention official support of Python 3.12 ... since tests are OK, I feel like it is ok to use an old version if someone needs it

I checked other deps and no update (widening of upper bound) is needed since no newer version exist