### PR TITLE
Mark package as typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ artifacts = [
 ]
 
 [tool.hatch.build.targets.sdist]
-include = [
+artifacts = [
   "src/zimscraperlib/rewriting/statics/**",
   "src/zimscraperlib/rewriting/rules.py",
   "tests/rewriting/test_fuzzy_rules.py",


### PR DESCRIPTION
Changes:
- add a `py.typed` marker file to indicate that the library is typed (at top-level obviously)
- fix `sdist` configuration (using `include` overrides the whole default logic of sdist content ; we only want to add few more files, which should be done with `artifacts` - just like for the wheel)

Nota: tested succesfully with mindtouch scraper which is now in `strict` type checking mode (on my dev machine, PR ongoing)