### PR TITLE
Add support for urllib3 2.3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   # youtube-dl should be updated as frequently as possible
   "yt-dlp",
   "pillow>=7.0.0,<12.0",
-  "urllib3>=1.26.5,<2.3.0",
+  "urllib3>=1.26.5,<2.4.0",
   "piexif==1.1.3", # this dep is a nightmare in terms of release management, better pinned just like in optimize-images anyway
   "idna>=2.5,<4.0"
 ]


### PR DESCRIPTION
Urllib3 2.3.0 is now out, and it is OK with our usage