### PR TITLE
Add JS rewriting rule to ignore import function rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade to wombat 3.8.11 (#256)
+- Backport changes in wabac.js around JS rewriting rules (#259)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade to wombat 3.8.11 (#256)
 
+### Fixed
+
+- JS rewriting abusively rewrite import function (#255)
+
 ## [5.1.1] - 2025-02-17
 
 ### Changed

--- a/src/zimscraperlib/rewriting/js.py
+++ b/src/zimscraperlib/rewriting/js.py
@@ -154,13 +154,15 @@ def create_js_rules() -> list[TransformationRule]:
     return [
         # rewriting `eval(...)` - invocation
         (re.compile(r"(?:^|\s)\beval\s*\("), replace_prefix_from(eval_str, "eval")),
+        (re.compile(r"\([\w]+,\s*eval\)\("), m2str(lambda _: f" {eval_str}")),
         # rewriting `x = eval` - no invocation
         (re.compile(r"[=]\s*\beval\b(?![(:.$])"), replace("eval", "self.eval")),
+        (re.compile(r"var\s+self"), replace("var", "let")),
         # rewriting `.postMessage` -> `__WB_pmw(self).postMessage`
         (re.compile(r"\.postMessage\b\("), add_prefix(".__WB_pmw(self)")),
         # rewriting `location = ` to custom expression `(...).href =` assignement
         (
-            re.compile(r"[^$.]?\s?\blocation\b\s*[=]\s*(?![\s\d=])"),
+            re.compile(r"(?:^|[^$.+*/%^-])\s?\blocation\b\s*[=]\s*(?![\s\d=])"),
             add_suffix_non_prop(check_loc),
         ),
         # rewriting `return this`

--- a/src/zimscraperlib/rewriting/js.py
+++ b/src/zimscraperlib/rewriting/js.py
@@ -186,6 +186,7 @@ def create_js_rules() -> list[TransformationRule]:
         # As the rule will match first, it will prevent next rule matching `import` to
         # be apply to `async import`.
         (re.compile(r"async\s+import\s*\("), m2str(lambda x: x)),
+        (re.compile(r"[^$.]\bimport\s*\([^)]*\)\s*\{"), m2str(lambda x: x)),
         # esm dynamic import, if found, mark as module
         (
             re.compile(r"[^$.]\bimport\s*\("),

--- a/tests/rewriting/test_js_rewriting.py
+++ b/tests/rewriting/test_js_rewriting.py
@@ -271,6 +271,12 @@ import {E, F, G} from "/path.js";
 import { Z } from "../../../path.js";
 
 B = await import(somefile);
+
+class X {
+  import(a, b, c) {
+    await import (somefile);
+  }
+}
 """,
             expected="""
 import * from "../../../example.com/file.js"
@@ -282,6 +288,12 @@ import {E, F, G} from "../../path.js";
 import { Z } from "../../path.js";
 
 B = await ____wb_rewrite_import__(import.meta.url, somefile);
+
+class X {
+  import(a, b, c) {
+    await ____wb_rewrite_import__ (import.meta.url, somefile);
+  }
+}
 """,
         ),
         ImportTestContent(
@@ -341,6 +353,7 @@ def test_import_rewrite(rewrite_import_content: ImportTestContent):
         "a.window.x = 5",
         "  postMessage({'a': 'b'})",
         "simport(5);",
+        "import(e) {",
         "a.import(5);",
         "$import(5);",
         "async import(val) { ... }",


### PR DESCRIPTION
Fix #255

For some reason, we were missing one JS rewriting rule implemented in wabac: https://github.com/webrecorder/wabac.js/blame/364b6e2d329f5ff92d680b482ec4f7e2036d6603/src/rewrite/jsrewriter.ts#L181

This has been put into wabac.js at https://github.com/webrecorder/wabac.js/pull/164 ; looks like we missed the opportunity to back-port this into our rewriting code. Most probably because we only focus on fuzzy rules and forgot to also consider these JS rewriting rules. I've updated the release checklist to also check this file.

I've also checked all other rules in this file and realized that we missed some other changes, not linked to this bug but still worth to include, so they are in a distinct commit.

To be merged after https://github.com/openzim/python-scraperlib/pull/257