### PR TITLE
Enhance save_large_file log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for custom number of retries and user-agent in save_large_file (#278)
+- Enhance save_large_file log level (#279)
 
 ### Fixed
 

--- a/src/zimscraperlib/download.py
+++ b/src/zimscraperlib/download.py
@@ -136,6 +136,7 @@ def save_large_file(
         f"{retries}",
         "--retry-connrefused",
         "--random-wait",
+        "--progress=dot:giga",
         "-O",
         str(fpath),
         "-c",


### PR DESCRIPTION
On "decent" connections like we have when we run a scraper, "--progress=dot:giga" log level is sufficient to get a log at least once a second. More verbose progress is just filling logs with unnecessary details.

Sample logs for a 312M file:

```
--2026-02-24 15:56:10--  https://assets.openfreemap.com/natural_earth/ofm.tar.gz
Resolving assets.openfreemap.com (assets.openfreemap.com)... 2a06:98c1:3121::3, 2a06:98c1:3120::3, 188.114.97.3, ...
Connecting to assets.openfreemap.com (assets.openfreemap.com)|2a06:98c1:3121::3|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 327659595 (312M) [application/octet-stream]
Saving to: ‘tmp/assets/natural_earth.tar.gz’

     0K ........ ........ ........ ........ 10% 54.5M 5s
 32768K ........ ........ ........ ........ 20% 60.7M 4s
 65536K ........ ........ ........ ........ 30% 47.2M 4s
 98304K ........ ........ ........ ........ 40% 31.9M 4s
131072K ........ ........ ........ ........ 51% 58.2M 3s
163840K ........ ........ ........ ........ 61% 56.3M 2s
196608K ........ ........ ........ ........ 71% 52.8M 2s
229376K ........ ........ ........ ........ 81% 58.1M 1s
262144K ........ ........ ........ ........ 92% 43.9M 0s
294912K ........ ........ ........         100% 46.5M=6.3s

2026-02-24 15:56:17 (49.4 MB/s) - ‘tmp/assets/natural_earth.tar.gz’ saved [327659595/327659595]
```

I don't think we should make this setting configurable, it looks like unnecessary burden for scraper developer. Even if connection if finally a bit slower, it should still update once every 10s or once every minute at worst (or scraper will probably not achieve to download the big file anyway).

@rgaudin WDYT?