### PR TITLE
Fix installation from source, which missed wombatSetup.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add proper typing @overload to `zimscraperlib.image.optimize_xxx` methods (#273)
 - Backport wabac.JS change around rewriting: detect when JS is in 'strict' mode and avoid using 'arguments' (#286)
+- Fix installation from source, which missed wombatSetup.js (#287)
 
 ### Changed
 

--- a/openzim.toml
+++ b/openzim.toml
@@ -8,3 +8,13 @@ execute_after=[
 action="get_file"
 source="https://cdn.jsdelivr.net/npm/@webrecorder/wombat@3.10.3/dist/wombat.js"
 target_file="wombat.js"
+
+# wombatSetup.js is supposed to be built locally from files in javascript folder.
+# Should someone install from Github repo directly, the configuration below ensures that
+# wombatSetup.js is downloaded from dev.kiwix.org, where we have the latest version from
+# `main` branch. wheel and sdist contains the wombatSetup.js which was built that time
+# (reminder: get_file action does not overwrite a file which already exists)
+[files.assets.actions."wombatSetup.js"]
+action="get_file"
+source="https://dev.kiwix.org/zimscraperlib/wombatSetup.js"
+target_file="wombatSetup.js"


### PR DESCRIPTION
When installing from source code, we do not retrieve wombatSetup.js from source code (this is expected) and we have nothing in the build chain which will build it. We hence need to add it to openzim.toml so that anyone using a dependency like `zimscraperlib @ git+https://github.com/openzim/python-scraperlib@main` will get a working setup.

This is not expected to have side-effects because it should anyway get "overridden" with proper version in real publication to PyPi.