### PR TITLE
Extend image optimization to support in-memory streams(BytesIO/bytes) and dst_format param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for custom number of retries and user-agent in save_large_file (#278)
 - Enhance save_large_file log level (#279)
+- Extend image optimization to support in-memory streams(BytesIO/bytes) and dst_format param (#289)
 
 ### Fixed
 

--- a/src/zimscraperlib/image/optimization.py
+++ b/src/zimscraperlib/image/optimization.py
@@ -22,8 +22,9 @@ import io
 import os
 import pathlib
 import subprocess
+import tempfile
+import warnings
 from dataclasses import dataclass
-from typing import overload
 
 import piexif  # pyright: ignore[reportMissingTypeStubs]
 from optimize_images.img_aux_processing import (  # pyright: ignore[reportMissingTypeStubs]
@@ -38,9 +39,7 @@ from optimize_images.img_dynamic_quality import (  # pyright: ignore[reportMissi
 )
 from PIL import Image
 
-from zimscraperlib.image.conversion import convert_image
 from zimscraperlib.image.probing import format_for
-from zimscraperlib.image.utils import save_image
 
 
 def ensure_matches(
@@ -79,46 +78,38 @@ class OptimizePngOptions:
     remove_transparency: bool | None = False
 
 
-@overload
-def optimize_png(
-    src: pathlib.Path | io.BytesIO,
-    dst: io.BytesIO | None = None,
-    options: OptimizePngOptions | None = None,
-) -> io.BytesIO: ...
-@overload
-def optimize_png(
-    src: pathlib.Path | io.BytesIO,
-    dst: pathlib.Path,
-    options: OptimizePngOptions | None = None,
-) -> pathlib.Path: ...
 def optimize_png(
     src: pathlib.Path | io.BytesIO,
     dst: pathlib.Path | io.BytesIO | None = None,
     options: OptimizePngOptions | None = None,
 ) -> pathlib.Path | io.BytesIO:
-    """method to optimize PNG files using a pure python external optimizer"""
-
-    ensure_matches(src, "PNG")
-
-    img = Image.open(src)
+    """method to convert (if needed) and optimize PNG files"""
 
     if options is None:
         options = OptimizePngOptions()
 
-    if options.remove_transparency:
-        img = remove_alpha(img, options.background_color)
+    with Image.open(src) as img:
+        if options.remove_transparency:
+            img = remove_alpha(img, options.background_color)  # noqa: PLW2901
 
-    if options.reduce_colors:
-        img, _, _ = do_reduce_colors(img, options.max_colors)
+        if options.reduce_colors:
+            img, _, _ = do_reduce_colors(img, options.max_colors)  # noqa: PLW2901
 
-    if not options.fast_mode and img.mode == "P":
-        img, _ = rebuild_palette(img)
+        if not options.fast_mode and img.mode == "P":
+            img, _ = rebuild_palette(img)  # noqa: PLW2901
 
-    if dst is None:
-        dst = io.BytesIO()
-    img.save(dst, optimize=True, format="PNG")
-    if not isinstance(dst, pathlib.Path):
-        dst.seek(0)
+        if dst is None:
+            dst = io.BytesIO()
+
+        try:
+            img.save(dst, optimize=True, format="PNG")
+            if isinstance(dst, io.BytesIO):
+                dst.seek(0)
+        except Exception as exc:  # pragma: no cover
+            if isinstance(dst, pathlib.Path) and dst.exists():
+                dst.unlink()
+            raise exc
+
     return dst
 
 
@@ -141,81 +132,87 @@ class OptimizeJpgOptions:
     keep_exif: bool | None = True
 
 
-@overload
-def optimize_jpeg(
-    src: pathlib.Path | io.BytesIO,
-    dst: io.BytesIO | None = None,
-    options: OptimizeJpgOptions | None = None,
-) -> io.BytesIO: ...
-@overload
-def optimize_jpeg(
-    src: pathlib.Path | io.BytesIO,
-    dst: pathlib.Path,
-    options: OptimizeJpgOptions | None = None,
-) -> pathlib.Path: ...
 def optimize_jpeg(
     src: pathlib.Path | io.BytesIO,
     dst: pathlib.Path | io.BytesIO | None = None,
     options: OptimizeJpgOptions | None = None,
 ) -> pathlib.Path | io.BytesIO:
-    """method to optimize JPEG files using a pure python external optimizer"""
+    """method to convert (if needed) and optimize JPEG files"""
 
     if options is None:
         options = OptimizeJpgOptions()
 
-    ensure_matches(src, "JPEG")
+    src_format = format_for(src, from_suffix=False)
 
-    img = Image.open(src)
-    orig_size = (
-        os.path.getsize(src)
-        if isinstance(src, pathlib.Path)
-        else src.getbuffer().nbytes
-    )
+    if isinstance(src, io.BytesIO):
+        src.seek(0)
 
-    had_exif = False
-    if (
-        not isinstance(src, pathlib.Path)
-        and piexif.load(src.getvalue())[  # pyright: ignore[reportUnknownMemberType]
-            "Exif"
-        ]
-    ) or (
-        isinstance(src, pathlib.Path)
-        and piexif.load(str(src))["Exif"]  # pyright: ignore[reportUnknownMemberType]
-    ):
-        had_exif = True
-
-    # only use progressive if file size is bigger
-    use_progressive_jpg = orig_size > 10240  # 10KiB  # noqa: PLR2004
-
-    if options.fast_mode:
-        quality_setting = options.quality
-    else:
-        quality_setting, _ = jpeg_dynamic_quality(img)
-
-    if dst is None:
-        dst = io.BytesIO()
-
-    img.save(
-        dst,
-        quality=quality_setting,
-        optimize=True,
-        progressive=use_progressive_jpg,
-        format="JPEG",
-    )
-
-    if isinstance(dst, io.BytesIO):
-        dst.seek(0)
-
-    if options.keep_exif and had_exif:
-        piexif.transplant(  # pyright: ignore[reportUnknownMemberType]
-            exif_src=(
-                str(src.resolve()) if isinstance(src, pathlib.Path) else src.getvalue()
-            ),
-            image=(
-                str(dst.resolve()) if isinstance(dst, pathlib.Path) else dst.getvalue()
-            ),
-            new_file=dst,
+    with Image.open(src) as img:
+        orig_size = (
+            os.path.getsize(src)
+            if isinstance(src, pathlib.Path)
+            else src.getbuffer().nbytes
         )
+
+        had_exif = False
+        if src_format == "JPEG":
+            if (
+                not isinstance(src, pathlib.Path)
+                and piexif.load(  # pyright: ignore[reportUnknownMemberType]
+                    src.getvalue()
+                )["Exif"]
+            ) or (
+                isinstance(src, pathlib.Path)
+                and piexif.load(str(src))[  # pyright: ignore[reportUnknownMemberType]
+                    "Exif"
+                ]
+            ):
+                had_exif = True
+
+        if src_format != "JPEG" and img.mode == "RGBA":
+            img = img.convert("RGB")  # noqa: PLW2901
+
+        # only use progressive if file size is bigger
+        use_progressive_jpg = orig_size > 10240  # 10KiB  # noqa: PLR2004
+
+        if options.fast_mode:
+            quality_setting = options.quality
+        else:
+            quality_setting, _ = jpeg_dynamic_quality(img)
+
+        if dst is None:
+            dst = io.BytesIO()
+
+        try:
+            img.save(
+                dst,
+                quality=quality_setting,
+                optimize=True,
+                progressive=use_progressive_jpg,
+                format="JPEG",
+            )
+
+            if isinstance(dst, io.BytesIO):
+                dst.seek(0)
+
+            if options.keep_exif and had_exif:
+                piexif.transplant(  # pyright: ignore[reportUnknownMemberType]
+                    exif_src=(
+                        str(src.resolve())
+                        if isinstance(src, pathlib.Path)
+                        else src.getvalue()
+                    ),
+                    image=(
+                        str(dst.resolve())
+                        if isinstance(dst, pathlib.Path)
+                        else dst.getvalue()
+                    ),
+                    new_file=dst,
+                )
+        except Exception as exc:  # pragma: no cover
+            if isinstance(dst, pathlib.Path) and dst.exists():
+                dst.unlink()
+            raise exc
 
     return dst
 
@@ -243,52 +240,35 @@ class OptimizeWebpOptions:
     lossless: bool | None = False
 
 
-@overload
-def optimize_webp(
-    src: pathlib.Path | io.BytesIO,
-    dst: io.BytesIO | None = None,
-    options: OptimizeWebpOptions | None = None,
-) -> io.BytesIO: ...
-@overload
-def optimize_webp(
-    src: pathlib.Path | io.BytesIO,
-    dst: pathlib.Path,
-    options: OptimizeWebpOptions | None = None,
-) -> pathlib.Path: ...
 def optimize_webp(
     src: pathlib.Path | io.BytesIO,
     dst: pathlib.Path | io.BytesIO | None = None,
     options: OptimizeWebpOptions | None = None,
 ) -> pathlib.Path | io.BytesIO:
-    """method to optimize WebP using Pillow options"""
+    """method to convert (if needed) and optimize WebP using Pillow options"""
 
     if options is None:
         options = OptimizeWebpOptions()
 
-    ensure_matches(src, "WEBP")
     params: dict[str, bool | int | None] = {
         "lossless": options.lossless,
         "quality": options.quality,
         "method": options.method,
     }
 
-    webp_image = Image.open(src)
-    if dst is None:
-        dst = io.BytesIO()
-        webp_image.save(dst, format="WEBP", **params)
-        dst.seek(0)
-    else:
+    with Image.open(src) as img:
+        if dst is None:
+            dst = io.BytesIO()
+
         try:
-            save_image(webp_image, dst, fmt="WEBP", **params)
+            img.save(dst, format="WEBP", **params)
+            if isinstance(dst, io.BytesIO):
+                dst.seek(0)
         except Exception as exc:  # pragma: no cover
-            if (
-                isinstance(src, pathlib.Path)
-                and isinstance(dst, pathlib.Path)
-                and src.resolve() != dst.resolve()
-                and dst.exists()
-            ):
+            if isinstance(dst, pathlib.Path) and dst.exists():
                 dst.unlink()
             raise exc
+
     return dst
 
 
@@ -322,37 +302,75 @@ class OptimizeGifOptions:
 
 
 def optimize_gif(
-    src: pathlib.Path, dst: pathlib.Path, options: OptimizeGifOptions | None = None
-) -> pathlib.Path:
-    """method to optimize GIFs using gifsicle >= 1.92"""
+    src: pathlib.Path | io.BytesIO,
+    dst: pathlib.Path | io.BytesIO,
+    options: OptimizeGifOptions | None = None,
+) -> pathlib.Path | io.BytesIO:
+    """method to convert (if needed) and optimize GIFs using gifsicle >= 1.92"""
 
     if options is None:
         options = OptimizeGifOptions()
 
-    ensure_matches(src, "GIF")
+    temp_files: list[pathlib.Path] = []
+    src_path = None
 
-    # use gifsicle
-    args = ["/usr/bin/env", "gifsicle"]
-    if options.optimize_level:
-        args += [f"-O{options.optimize_level}"]
-    if options.max_colors:
-        args += ["--colors", str(options.max_colors)]
-    if options.lossiness:
-        args += [f"--lossy={options.lossiness}"]
-    if options.no_extensions:
-        args += ["--no-extensions"]
-    if options.interlace:
-        args += ["--interlace"]
-    args += [str(src)]
-    with open(dst, "w") as out_file:
-        gifsicle = subprocess.run(args, stdout=out_file, check=False)
+    try:
+        src_format = format_for(src, from_suffix=False)
 
-    # remove dst if gifsicle failed and src is different from dst
-    if gifsicle.returncode != 0 and src.resolve() != dst.resolve() and dst.exists():
-        dst.unlink()  # pragma: no cover
+        if isinstance(src, io.BytesIO):
+            src.seek(0)
 
-    # raise error if unsuccessful
-    gifsicle.check_returncode()
+        if src_format != "GIF":
+            with tempfile.NamedTemporaryFile(suffix=".gif", delete=False) as tmp:
+                src_path = pathlib.Path(tmp.name)
+            temp_files.append(src_path)
+            with Image.open(src) as img:
+                if img.mode == "RGBA":
+                    img = img.convert("RGB")  # noqa: PLW2901
+                img.save(src_path, format="GIF")
+        elif isinstance(src, io.BytesIO):
+            with tempfile.NamedTemporaryFile(suffix=".gif", delete=False) as tmp:
+                src_path = pathlib.Path(tmp.name)
+            src_path.write_bytes(src.read())
+            temp_files.append(src_path)
+        else:
+            src_path = src
+
+        # use gifsicle
+        args = ["/usr/bin/env", "gifsicle"]
+        if options.optimize_level:
+            args += [f"-O{options.optimize_level}"]
+        if options.max_colors:
+            args += ["--colors", str(options.max_colors)]
+        if options.lossiness:
+            args += [f"--lossy={options.lossiness}"]
+        if options.no_extensions:
+            args += ["--no-extensions"]
+        if options.interlace:
+            args += ["--interlace"]
+        args += [str(src_path)]
+
+        if isinstance(dst, io.BytesIO):
+            gifsicle = subprocess.run(args, capture_output=True, check=False)
+            if gifsicle.returncode != 0:
+                dst.seek(0)
+                dst.truncate()
+            else:
+                dst.write(gifsicle.stdout)
+                dst.seek(0)
+            gifsicle.check_returncode()
+        else:
+            with open(dst, "wb") as out_file:
+                gifsicle = subprocess.run(args, stdout=out_file, check=False)
+            # remove dst if gifsicle failed and src is different from dst
+            if gifsicle.returncode != 0 and src_path != dst and dst.exists():
+                dst.unlink()
+            gifsicle.check_returncode()
+
+    finally:
+        for temp_file in temp_files:
+            temp_file.unlink(missing_ok=True)
+
     return dst
 
 
@@ -383,56 +401,75 @@ class OptimizeOptions:
 
 
 def optimize_image(
-    src: pathlib.Path,
-    dst: pathlib.Path,
+    src: pathlib.Path | io.BytesIO | bytes,
+    dst: pathlib.Path | io.BytesIO,
     options: OptimizeOptions | None = None,
     *,
-    delete_src: bool | None = False,
-    convert: bool | str | None = False,
-):
+    dst_format: str | None = None,
+    delete_src: bool = False,
+    convert: bool | str = False,
+) -> pathlib.Path | io.BytesIO:
     """Optimize image, automatically selecting correct optimizer
 
     Arguments:
+        dst_format: format of the destination image,
+            required when dst is io.BytesIO.
         delete_src: whether to remove src file upon success (boolean)
             values: True | False
-        convert: whether/how to convert from source before optimizing (str or boolean)
+        convert: will be deprecated in scraperlib 6, use dst_format instead.
             values: False: don't convert
                     True: convert to format implied by dst suffix
-                    "FMT": convert to format FMT (use Pillow names)"""
+                    str: convert to the specified format"""
+
+    if convert is not False:
+        warnings.warn(
+            "The 'convert' param is deprecated and will be removed in scraperlib 6."
+            "Use 'dst_format' parameter instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        if isinstance(convert, str):
+            dst_format = convert
 
     if options is None:
         options = OptimizeOptions.of()
 
-    src_format, dst_format = format_for(src, from_suffix=False), format_for(dst)
+    if isinstance(src, bytes):
+        src = io.BytesIO(src)
 
-    if src_format is None:  # pragma: no cover
-        # never supposed to happens since we get format from suffix, but good for type
-        # checker + code safety / clean errors
-        raise ValueError("Impossible to guess format from src image")
-    if dst_format is None:
-        raise ValueError("Impossible to guess format from dst image")
-    # if requested, convert src to requested format into dst path
-    if convert and src_format != dst_format:
-        src_format = dst_format = convert if isinstance(convert, str) else dst_format
-        convert_image(src, dst, fmt=src_format)
-        src_img = pathlib.Path(dst)
-    else:
-        src_img = pathlib.Path(src)
+    if delete_src and isinstance(src, io.BytesIO):
+        raise ValueError("delete_src is not applicable when src is io.BytesIO or bytes")
 
-    src_format = src_format.lower()
-    if src_format in ("jpg", "jpeg"):
-        optimize_jpeg(src=src_img, dst=dst, options=options.jpg)
-    elif src_format == "gif":
-        optimize_gif(src=src_img, dst=dst, options=options.gif)
-    elif src_format == "png":
-        optimize_png(src=src_img, dst=dst, options=options.png)
-    elif src_format == "webp":
-        optimize_webp(src=src_img, dst=dst, options=options.webp)
+    if isinstance(dst, pathlib.Path):
+        dst_format = dst_format or format_for(dst)
+        if dst_format is None:
+            raise ValueError("Impossible to guess format from dst image")
+    elif dst_format is None:
+        raise ValueError("dst_format is required when dst is io.BytesIO")
+    dst_format = dst_format.lower()
+
+    if dst_format in ("jpg", "jpeg"):
+        optimize_jpeg(src=src, dst=dst, options=options.jpg)
+    elif dst_format == "gif":
+        optimize_gif(src=src, dst=dst, options=options.gif)
+    elif dst_format == "png":
+        optimize_png(src=src, dst=dst, options=options.png)
+    elif dst_format == "webp":
+        optimize_webp(src=src, dst=dst, options=options.webp)
     else:
         raise NotImplementedError(
-            f"Image format '{src_format}' cannot yet be optimized"
+            f"Image format '{dst_format}' cannot yet be optimized"
         )
 
-    # delete src image if requested
-    if delete_src and src.exists() and src.resolve() != dst.resolve():
+    if (
+        delete_src
+        and isinstance(src, pathlib.Path)
+        and src.exists()
+        and isinstance(dst, pathlib.Path)
+        and dst.exists()
+        and not src.samefile(dst)
+    ):
         src.unlink()
+
+    return dst

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -4,12 +4,14 @@ import os
 import pathlib
 import re
 import shutil
+import subprocess
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
 import piexif  # pyright: ignore[reportMissingTypeStubs]
 import pytest
 from PIL import Image
+from pytest_mock import MockerFixture
 from resizeimage.imageexceptions import (  # pyright: ignore[reportMissingTypeStubs]
     ImageSizeError,
 )
@@ -469,10 +471,9 @@ def test_wrong_extension(
         create_favicon(src, dst)
 
 
-@pytest.mark.parametrize(
-    "fmt",
-    ["png", "jpg", "gif", "webp"],
-)
+@pytest.mark.parametrize("fmt", ["png", "jpg", "gif", "webp"])
+@pytest.mark.parametrize("src_type", ["path", "bytesio", "bytes"])
+@pytest.mark.parametrize("dst_type", ["path", "bytesio"])
 def test_optimize_image_default_generic(
     png_image2: pathlib.Path,
     jpg_image: pathlib.Path,
@@ -480,8 +481,10 @@ def test_optimize_image_default_generic(
     webp_image: pathlib.Path,
     tmp_path: pathlib.Path,
     fmt: str,
+    src_type: str,
+    dst_type: str,
 ):
-    src, dst = get_src_dst(
+    src, dst_path = get_src_dst(
         tmp_path,
         fmt,
         png_image=png_image2,
@@ -489,14 +492,31 @@ def test_optimize_image_default_generic(
         gif_image=gif_image,
         webp_image=webp_image,
     )
-    optimize_image(src, dst, delete_src=False)
-    assert os.path.getsize(dst) < os.path.getsize(src)
+    original_size = os.path.getsize(src)
+
+    if src_type == "bytesio":
+        src = io.BytesIO(src.read_bytes())
+    elif src_type == "bytes":
+        src = src.read_bytes()
+
+    dst = io.BytesIO() if dst_type == "bytesio" else dst_path
+    optimize_image(src, dst, dst_format=fmt)
+
+    if dst_type == "path":
+        assert isinstance(dst, pathlib.Path)
+        assert dst.exists()
+        assert os.path.getsize(dst) < original_size
+        assert os.path.getsize(dst) > 0
+    else:
+        assert isinstance(dst, io.BytesIO)
+        assert dst.getbuffer().nbytes > 0
+        dst.seek(0)
+        assert Image.open(dst).format == fmt.upper().replace("JPG", "JPEG")
 
 
-@pytest.mark.parametrize(
-    "fmt",
-    ["png", "jpg", "gif", "webp"],
-)
+@pytest.mark.parametrize("fmt", ["png", "jpg", "gif", "webp"])
+@pytest.mark.parametrize("src_type", ["path", "bytesio"])
+@pytest.mark.parametrize("dst_type", ["path", "bytesio"])
 def test_optimize_image_default_direct(
     png_image2: pathlib.Path,
     jpg_image: pathlib.Path,
@@ -504,8 +524,10 @@ def test_optimize_image_default_direct(
     webp_image: pathlib.Path,
     tmp_path: pathlib.Path,
     fmt: str,
+    src_type: str,
+    dst_type: str,
 ):
-    src, dst = get_src_dst(
+    src, dst_path = get_src_dst(
         tmp_path,
         fmt,
         png_image=png_image2,
@@ -513,6 +535,12 @@ def test_optimize_image_default_direct(
         gif_image=gif_image,
         webp_image=webp_image,
     )
+    original_size = os.path.getsize(src)
+
+    if src_type == "bytesio":
+        src = io.BytesIO(src.read_bytes())
+
+    dst = io.BytesIO() if dst_type == "bytesio" else dst_path
 
     if fmt in ("jpg", "jpeg"):
         optimize_jpeg(src=src, dst=dst)
@@ -524,7 +552,17 @@ def test_optimize_image_default_direct(
         optimize_webp(src=src, dst=dst)
     else:
         raise NotImplementedError(f"Image format '{fmt}' cannot yet be optimized")
-    assert os.path.getsize(dst) < os.path.getsize(src)
+
+    if dst_type == "path":
+        assert isinstance(dst, pathlib.Path)
+        assert dst.exists()
+        assert os.path.getsize(dst) < original_size
+        assert os.path.getsize(dst) > 0
+    else:
+        assert isinstance(dst, io.BytesIO)
+        assert dst.getbuffer().nbytes > 0
+        dst.seek(0)
+        assert Image.open(dst).format == fmt.upper().replace("JPG", "JPEG")
 
 
 def test_optimize_image_del_src(png_image: pathlib.Path, tmp_path: pathlib.Path):
@@ -537,21 +575,81 @@ def test_optimize_image_del_src(png_image: pathlib.Path, tmp_path: pathlib.Path)
     assert not src.exists()
 
 
-def test_optimize_image_allow_convert(png_image: pathlib.Path, tmp_path: pathlib.Path):
-    shutil.copy(png_image, tmp_path)
-    src = tmp_path / png_image.name
-    dst = tmp_path / "out.webp"
-    optimize_image(src, dst, delete_src=True, convert=True)
-    assert not src.exists()
-    assert dst.exists() and os.path.getsize(dst) > 0
-
-
 def test_optimize_image_bad_dst(png_image: pathlib.Path, tmp_path: pathlib.Path):
     shutil.copy(png_image, tmp_path)
     src = tmp_path / png_image.name
     dst = tmp_path / "out.raster"
     with pytest.raises(ValueError, match="Impossible to guess format from dst image"):
-        optimize_image(src, dst, delete_src=True, convert=True)
+        optimize_image(src, dst)
+
+
+def test_optimize_image_unidentifiable_src(tmp_path: pathlib.Path):
+    src = tmp_path / "file.gbr"
+    src.write_bytes(b"test gbr content")
+    dst = tmp_path / "out.png"
+    with pytest.raises(Image.UnidentifiedImageError):
+        optimize_image(src, dst)
+
+
+def test_optimize_image_unsupported_format_dst(png_image: pathlib.Path):
+    src = png_image
+    dst = io.BytesIO()
+    with pytest.raises(
+        NotImplementedError, match="Image format 'bmp' cannot yet be optimized"
+    ):
+        optimize_image(src, dst, dst_format="bmp")
+
+
+def test_optimize_image_missing_dst_format_for_bytesio(png_image: pathlib.Path):
+    src = png_image
+    dst = io.BytesIO()
+    with pytest.raises(
+        ValueError, match=re.escape("dst_format is required when dst is io.BytesIO")
+    ):
+        optimize_image(src, dst)
+
+
+def test_optimize_image_delete_src_not_applicable_for_bytesio():
+    src = io.BytesIO(b"test image data")
+    dst = io.BytesIO()
+    with pytest.raises(
+        ValueError,
+        match=re.escape("delete_src is not applicable when src is io.BytesIO or bytes"),
+    ):
+        optimize_image(src, dst, dst_format="png", delete_src=True)
+
+
+def test_optimize_image_delete_src_not_applicable_for_bytes():
+    src = b"test image data"
+    dst = io.BytesIO()
+    with pytest.raises(
+        ValueError,
+        match=re.escape("delete_src is not applicable when src is io.BytesIO or bytes"),
+    ):
+        optimize_image(src, dst, dst_format="png", delete_src=True)
+
+
+def test_optimize_image_deprecated_convert_str(png_image: pathlib.Path):
+    src = png_image
+    dst = io.BytesIO()
+    with pytest.warns(DeprecationWarning, match="The 'convert' param is deprecated"):
+        optimize_image(src, dst, convert="jpg")
+
+    dst.seek(0)
+    assert Image.open(dst).format == "JPEG"
+
+
+def test_optimize_image_deprecated_convert_true(
+    png_image: pathlib.Path, tmp_path: pathlib.Path
+):
+    src = png_image
+    dst = tmp_path / "out.jpg"
+
+    with pytest.warns(DeprecationWarning, match="The 'convert' param is deprecated"):
+        optimize_image(src, dst, convert=True)
+
+    assert dst.exists()
+    assert Image.open(dst).format == "JPEG"
 
 
 @pytest.mark.parametrize(
@@ -779,15 +877,6 @@ def test_image_preset_jpg(
     assert dst_bytes.getbuffer().nbytes < byte_stream.getbuffer().nbytes
 
 
-def test_optimize_image_unsupported_format():
-    src = pathlib.Path(__file__).parent.parent / "files" / "single_wave_icon.gbr"
-    dst = pathlib.Path("image.png")
-    with pytest.raises(
-        NotImplementedError, match="Image format 'gbr' cannot yet be optimized"
-    ):
-        optimize_image(src, dst, delete_src=False)
-
-
 def test_image_preset_has_mime_and_ext():
     for _, preset in ALL_PRESETS:
         assert preset().ext
@@ -943,13 +1032,6 @@ def test_format_for_cannot_use_suffix_with_byte_array():
         assert format_for(src=io.BytesIO(), from_suffix=True)
 
 
-def test_wrong_extension_optim(tmp_path: pathlib.Path, png_image: pathlib.Path):
-    dst = tmp_path.joinpath("image.jpg")
-    shutil.copy(png_image, dst)
-    with pytest.raises(ValueError, match=re.escape("is not of format JPEG")):
-        optimize_jpeg(dst, dst)
-
-
 def test_is_valid_image(
     png_image: pathlib.Path,
     png_image2: pathlib.Path,
@@ -987,6 +1069,72 @@ def test_optimize_gif_no_interlace(gif_image: pathlib.Path, tmp_path: pathlib.Pa
     optimize_gif(
         gif_image, tmp_path / "out.gif", options=OptimizeGifOptions(interlace=None)
     )
+
+
+def test_optimize_gif_with_non_gif_src(png_image: pathlib.Path, tmp_path: pathlib.Path):
+    dst = tmp_path / "out.gif"
+    result = optimize_gif(src=png_image, dst=dst)
+    assert isinstance(result, pathlib.Path)
+    assert result == dst
+    assert dst.exists()
+    assert Image.open(dst).format == "GIF"
+
+
+def test_optimize_gif_with_rgb_src(tmp_path: pathlib.Path):
+    img = Image.new("RGB", (100, 100), color=(255, 0, 0))
+    src = tmp_path / "rgb.png"
+    img.save(src, format="PNG")
+
+    dst = tmp_path / "out.gif"
+    optimize_gif(src=src, dst=dst)
+
+    assert dst.exists()
+    assert Image.open(dst).format == "GIF"
+
+
+def test_optimize_gif_gifsicle_failure_path(
+    gif_image: pathlib.Path, tmp_path: pathlib.Path, mocker: MockerFixture
+):
+    gifsicle = subprocess.CompletedProcess(
+        args=["gifsicle"],
+        returncode=1,
+        stdout=b"",
+        stderr=b"gifsicle processing failed",
+    )
+    mocker.patch(
+        "zimscraperlib.image.optimization.subprocess.run", return_value=gifsicle
+    )
+
+    dst = tmp_path / "out.gif"
+    dst.touch()
+
+    with pytest.raises(subprocess.CalledProcessError):
+        optimize_gif(src=gif_image, dst=dst)
+
+    assert not dst.exists()
+
+
+def test_optimize_gif_gifsicle_failure_bytesio(
+    gif_image: pathlib.Path, mocker: MockerFixture
+):
+    gifsicle = subprocess.CompletedProcess(
+        args=["gifsicle"],
+        returncode=1,
+        stdout=b"",
+        stderr=b"gifsicle processing failed",
+    )
+    mocker.patch(
+        "zimscraperlib.image.optimization.subprocess.run", return_value=gifsicle
+    )
+
+    src_bytes = io.BytesIO(gif_image.read_bytes())
+    dst_bytes = io.BytesIO(b"data to be cleared")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        optimize_gif(src=src_bytes, dst=dst_bytes)
+
+    dst_bytes.seek(0)
+    assert dst_bytes.read() == b""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #284

Changes:
- Modified `optimize_image` and `optimize_gif` to accept `io.BytesIO` as input
- Added support for `bytes`  as `src`  inside `optimize_image`
- `convert` parameter deprecated for `optimize_image`. Users should now use `dst_format` instead.
- Delegated format conversion to `optimize_xxx` methods
- Added test cases for BytesIO/bytes support and dst_format param