### PR TITLE
fix(zim): correct config_indexing docstring to full-text only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix installation from source, which missed wombatSetup.js (#287)
 - Fix outdated system dependencies in README: remove Pillow build-time deps (bundled in wheels), add missing `libcairo` across all platforms (#152)
 - Improve contribution setup instructions: use `hatch shell`, clarify commands must be run from local clone root (#153)
+- Fix `Creator.config_indexing` docstring to reflect that only the full-text index is toggled; title indexing is always performed by libzim (#294)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix outdated system dependencies in README: remove Pillow build-time deps (bundled in wheels), add missing `libcairo` across all platforms (#152)
 - Improve contribution setup instructions: use `hatch shell`, clarify commands must be run from local clone root (#153)
 - Bring coverage back to 100% (#293)
+- Fix `Creator.config_indexing` docstring to reflect that only the full-text index is toggled; title indexing is always performed by libzim (#294)
 
 ### Changed
 

--- a/src/zimscraperlib/zim/creator.py
+++ b/src/zimscraperlib/zim/creator.py
@@ -127,9 +127,12 @@ class Creator(libzim.writer.Creator):
     def config_indexing(
         self, indexing: bool, language: str | None = None  # noqa: FBT001
     ):
-        """Toggle full-text and title indexing of entries
+        """Toggle full-text indexing of entries
 
-        Uses Language metadata's value (or "") if not set"""
+        Uses Language metadata's value (or "") if not set.
+
+        Note: title indexing is always performed by libzim and cannot be
+        disabled via this method; only the full-text index is toggled."""
         language = language or self._get_first_language_metadata_value() or ""
         if indexing and not is_valid_iso_639_3(language):
             raise ValueError("Not a valid ISO-639-3 language code")

--- a/tests/zim/test_zim_creator.py
+++ b/tests/zim/test_zim_creator.py
@@ -973,3 +973,11 @@ def test_config_indexing(tmp_path: pathlib.Path):
     assert Creator(tmp_path / "_.zim", "").config_indexing(True, "bam")
     assert Creator(tmp_path / "_.zim", "").config_indexing(False, "bam")
     assert Creator(tmp_path / "_.zim", "").config_indexing(False)
+
+
+def test_config_indexing_docstring_only_mentions_full_text():
+    """Regression test for #294: docstring must not claim title indexing
+    is toggled (libzim only toggles the full-text index)."""
+    doc = Creator.config_indexing.__doc__ or ""
+    assert "full-text" in doc
+    assert "full-text and title indexing" not in doc


### PR DESCRIPTION
Closes #294

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo

openzim/python-scraperlib

## Issue

https://github.com/openzim/python-scraperlib/issues/294

## Root cause

The docstring of `Creator.config_indexing` in `src/zimscraperlib/zim/creator.py` stated it toggled "full-text and title indexing of entries". In reality, libzim's `config_indexing` only toggles the full-text index; the title index is always built. The python-scraperlib documentation was therefore misleading.

## Fix

Updated the docstring of `Creator.config_indexing` to state it toggles full-text indexing only and added an explicit note that title indexing is always performed by libzim and cannot be disabled via this method.

## Regression test

`tests/zim/test_zim_creator.py::test_config_indexing_docstring_only_mentions_full_text` asserts the docstring contains "full-text" and does NOT contain the misleading phrase "full-text and title indexing".

## Risk

trivial

## Verification

Local pytest plugin environment was broken (missing `textual` module unrelated to this repo). Verified the fix via AST inspection of the updated source: the docstring contains "full-text" and no longer contains "full-text and title indexing" — matching the regression test's assertions. Result: PASS.
