### PR TITLE
chore(ci): upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -28,7 +28,7 @@ jobs:
           python rules/generate_rules.py
 
       - name: Save rules artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             src/zimscraperlib/rewriting/rules.py
@@ -44,15 +44,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore rules artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rules
 
       - name: Setup Node.JS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'javascript/package.json'
 
@@ -65,7 +65,7 @@ jobs:
         working-directory: javascript
 
       - name: Save wombat-setup artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: javascript/dist/wombatSetup.js
           name: wombat-setup
@@ -81,21 +81,21 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore rules artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rules
 
       - name: Restore wombat-setup artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wombat-setup
           path: src/zimscraperlib/rewriting/statics
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -106,7 +106,7 @@ jobs:
           python -m build --sdist --wheel
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12
+        uses: pypa/gh-action-pypi-publish@release/v1.14
 # OPTIONAL PUBLICATION TO NPM, NOT NEEDED BY SCRAPERS IN THE END
 
 # publish-js:
@@ -116,15 +116,15 @@ jobs:
 
 #   steps:
 #     - name: Checkout repo
-#       uses: actions/checkout@v4
+#       uses: actions/checkout@v6
 
 #     - name: Restore rules artifact
-#       uses: actions/download-artifact@v4
+#       uses: actions/download-artifact@v8
 #       with:
 #         name: rules
 
 #     - name: Setup Node.JS
-#       uses: actions/setup-node@v4
+#       uses: actions/setup-node@v6
 #       with:
 #         node-version-file: 'javascript/package.json'
 #         registry-url: 'https://registry.npmjs.org' # Setup .npmrc file to publish to npm

--- a/.github/workflows/PublishDev.yaml
+++ b/.github/workflows/PublishDev.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -29,7 +29,7 @@ jobs:
           python rules/generate_rules.py
 
       - name: Setup Node.JS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'javascript/package.json'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -30,7 +30,7 @@ jobs:
           python rules/generate_rules.py
 
       - name: Save rules artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             src/zimscraperlib/rewriting/rules.py
@@ -46,15 +46,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore rules artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rules
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -79,15 +79,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore rules artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rules
 
       - name: Setup Node.JS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'javascript/package.json'
 

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -30,7 +30,7 @@ jobs:
           python rules/generate_rules.py
 
       - name: Save rules artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             src/zimscraperlib/rewriting/rules.py
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore rules artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rules
 
@@ -57,7 +57,7 @@ jobs:
         run: sudo apt update && sudo apt install ffmpeg gifsicle
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -71,7 +71,7 @@ jobs:
         run: inv coverage --args "--runslow --runinstalled -vvv"
 
       - name: Upload coverage report to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -87,15 +87,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore rules artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rules
 
       - name: Setup Node.JS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'javascript/package.json'
 
@@ -125,10 +125,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -141,7 +141,7 @@ jobs:
         run: hatch run docs:build
 
       - name: Save doc artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             site/


### PR DESCRIPTION
Closes #310.

Bumps actions referenced in `.github/workflows/*` to their latest major versions, moving them onto Node 24 runtimes ahead of GitHub's Node 20 deprecation.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `codecov/codecov-action` | v4 | **v6** |
| `pypa/gh-action-pypi-publish` | release/v1.12 | **release/v1.14** |

### Notes

- `upload-artifact@v5` introduced a breaking change in default artifact behaviour, but v7 is the current major and consistent with the matching `download-artifact@v8`.
- `codecov/codecov-action@v5+` switched to the wrapper for the new Codecov uploader; the existing `token` and `fail_ci_if_error` inputs continue to work.
- `pypa/gh-action-pypi-publish` is referenced via its `release/v1.14` branch, matching upstream's recommended pinning style and the previous `release/v1.12`.
- The commented-out `publish-js` block at the bottom of `Publish.yaml` was bumped in the same pass so it stays consistent if re-enabled later.

### Testing

CI on this PR will exercise every bumped action across the QA and Tests workflows. The `Publish` workflow only runs on release publication, so it can't be exercised here, but it uses the same action set.